### PR TITLE
Updated C++11 check macros; attempt to fix build issue on clang

### DIFF
--- a/src/network/uri/config.hpp
+++ b/src/network/uri/config.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) Glyn Matthews 2012.
+// Copyright (c) Glyn Matthews 2012, 2013.
 // Copyright 2012 Dean Michael Berris <dberris@google.com>
 // Copyright 2012 Google, Inc.
 // Distributed under the Boost Software License, Version 1.0.
@@ -17,5 +17,24 @@
 #else
 #define NETWORK_URI_DECL
 #endif // defined(BOOST_ALL_DYN_LINK) || defined(BOOST_URI_DYN_LINK)
+
+#if !defined(BOOST_NO_CXX11_NOEXCEPT)
+#define NETWORK_URI_NOEXCEPT noexcept
+#else
+#define NETWORK_URI_NOEXCEPT
+#endif // !defined(BOOST_NO_CXX11_NOEXCEPT)
+
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+#define NETWORK_URI_DEFAULTED_FUNCTION = default
+#else
+#define NETWORK_URI_DEFAULTED_FUNCTION
+#endif // !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+
+#if !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+#define NETWORK_URI_DELETED_FUNCTION = delete
+#else
+#define NETWORK_URI_DELETED_FUNCTION
+#endif // !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+
 
 #endif // NETWORK_URI_CONFIG_INC

--- a/src/network/uri/uri.hpp
+++ b/src/network/uri/uri.hpp
@@ -39,19 +39,12 @@ namespace network {
 
   public:
 
-    uri_category_impl();
+    uri_category_impl() NETWORK_URI_DEFAULTED_FUNCTION;
 
-#if defined(BOOST_NO_CXX11_NOEXCEPT)
-    virtual ~uri_category_impl();
-#else
-    virtual ~uri_category_impl() noexcept;
-#endif // defined(BOOST_NO_CXX11_NOEXCEPT)
+    virtual ~uri_category_impl() NETWORK_URI_NOEXCEPT;
 
-#if defined(BOOST_NO_CXX11_NOEXCEPT)
-    virtual const char *name() const;
-#else
-    virtual const char *name() const noexcept;
-#endif // defined(BOOST_NO_CXX11_NOEXCEPT)
+    virtual const char *name() const NETWORK_URI_NOEXCEPT;
+
     virtual std::string message(int ev) const;
 
   };

--- a/src/uri.cpp
+++ b/src/uri.cpp
@@ -26,23 +26,17 @@
 #include <vector>
 
 namespace network {
+#if defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
   uri_category_impl::uri_category_impl() {
 
   }
+#endif // defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
 
-#if defined(BOOST_NO_CXX11_NOEXCEPT)
-  uri_category_impl::~uri_category_impl() {
-#else
-  uri_category_impl::~uri_category_impl() noexcept {
-#endif // defined(BOOST_NO_CXX11_NOEXCEPT)
+  uri_category_impl::~uri_category_impl() NETWORK_URI_NOEXCEPT {
 
   }
 
-#if defined(BOOST_NO_CXX11_NOEXCEPT)
-  const char *uri_category_impl::name() const {
-#else
-  const char *uri_category_impl::name() const noexcept {
-#endif // defined(BOOST_NO_CXX11_NOEXCEPT)
+  const char *uri_category_impl::name() const NETWORK_URI_NOEXCEPT {
     return "uri_error";
   }
 


### PR DESCRIPTION
The `error_category_impl` class constructor is now defaulted (where it is available). I updated the config.hpp to make the code easier to read when trying to use C++11 features that are not available on every compiler.
