### PR TITLE
Add equality operator between string_view and char*

### DIFF
--- a/src/network/uri/uri.hpp
+++ b/src/network/uri/uri.hpp
@@ -101,6 +101,8 @@ namespace network {
 
   class uri_builder;
 
+  typedef boost::string_ref string_view;
+  
   class NETWORK_URI_DECL uri {
 
     friend class uri_builder;
@@ -111,7 +113,6 @@ namespace network {
     typedef string_type::const_iterator const_iterator;
     typedef const_iterator iterator;
     typedef std::iterator_traits<iterator>::value_type value_type;
-    typedef boost::string_ref string_view;
 
   private:
 
@@ -290,6 +291,11 @@ namespace network {
   inline
   bool operator >= (const uri &lhs, const uri &rhs) {
     return !(lhs < rhs);
+  }
+  
+  inline
+  bool operator == (const string_view lhs, const char* rhs) {
+    return std::equal(lhs.begin(), lhs.end(), rhs) && !rhs[lhs.size() + 1];
   }
 } // namespace network
 


### PR DESCRIPTION
Hi,
boost::string_ref don't have an equality operator between string_view and char*, so I added one

It first compare using std::equal and if it return true then search if we are at the end of the char*

I didn't search first for the possible \0 charter at size() + 1 because possible memory check made by OS/C++ runtime (or it's safe?)

I'm just started learning C++, so I don't know if this commit it's ok

The test suite for uri it's all green
