### PR TITLE
Use the flags of the parent project with regards to shared Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,13 @@ cmake_minimum_required(VERSION 2.8)
 project(Uri)
 
 find_package(Threads REQUIRED)
-set(Boost_USE_STATIC_LIBS ON)
+
+if(CPP-NETLIB_BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
+  set(Boost_USE_STATIC_LIBS OFF)
+else()
+  set(Boost_USE_STATIC_LIBS ON)
+endif()
+
 set(Boost_USE_MULTITHREADED ON)
 find_package(Boost 1.53 REQUIRED system filesystem)
 


### PR DESCRIPTION
Tested on linux with cmake 2.8.11.2
