### PR TITLE
Using CMAKE_INSTALL_PREFIX in install command is redundant.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,11 +24,11 @@ if(NOT CPP-NETLIB_BUILD_SINGLE_LIB)
   install(
     TARGETS
     network-uri
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+    DESTINATION lib
     )
 
   install(DIRECTORY network
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+    DESTINATION include
     )
 endif()
 


### PR DESCRIPTION
From documentation (http://www.cmake.org/cmake/help/v2.8.12/cmake.html#command:install):
    If a relative path is given it is interpreted relative to the value of CMAKE_INSTALL_PREFIX.
