### PR TITLE
Fix host parsing priority according to RFC 3986.

### DIFF
--- a/src/detail/uri_parse.cpp
+++ b/src/detail/uri_parse.cpp
@@ -137,8 +137,11 @@ namespace network {
         // reg-name = *( unreserved / pct-encoded / sub-delims )
         reg_name %= qi::raw[*(unreserved | pct_encoded | sub_delims)];
 
-        // TODO, host = IP-literal / IPv4address / reg-name
-        host %= qi::raw[ip_literal | ipv4address | reg_name];
+        // host = IP-literal / IPv4address / reg-name
+        // This should be priority ordering, but Spirit is greedy
+        // and will fail if 'host' starts with 'ipv4address'. We make
+        // sure there isn't another '.' after last IPv4 octet.
+        host %= qi::raw[ip_literal | (ipv4address >> !(&qi::lit('.'))) | reg_name];
 
         port %= qi::raw[qi::ushort_ | qi::eps];
 

--- a/test/uri_test.cpp
+++ b/test/uri_test.cpp
@@ -28,6 +28,18 @@ TEST(uri_test, construct_uri_from_char_array) {
   ASSERT_NO_THROW(network::uri("http://www.example.com/"));
 }
 
+TEST(uri_test, construct_uri_starting_with_ipv4_like) {
+  ASSERT_NO_THROW(network::uri("http://198.51.100.0.example.com/"));
+}
+
+TEST(uri_test, construct_uri_like_short_ipv4) {
+  ASSERT_NO_THROW(network::uri("http://198.51.100/"));
+}
+
+TEST(uri_test, construct_uri_like_long_ipv4) {
+  ASSERT_NO_THROW(network::uri("http://198.51.100.0.255/"));
+}
+
 TEST(uri_test, make_uri_from_char_array) {
   std::error_code ec;
   network::uri uri = network::make_uri("http://www.example.com/", ec);


### PR DESCRIPTION
This should fix cpp-netlib/cpp-netlib#450. There isn't an issue for this in the cpp-netlib/uri repository.

The host rule is ambiguous unless we process the subrules in specific order and pick the first which matches.

However, Spirit parser is greedy and will match hostnames like `1.2.3.4.example.com` to be an IPv4 address. Then we return from the host rule and further parsing will fail (trying to parse `.example.com` as port or path).

To fix this, we make sure that there isn't another dot after the IP. This fixes hosts which have some IPv4 address like prefix. The `ip_literal` rule doesn't need this, since it's wrapped inside `[]` and thus is unambiguous.

I've added two test cases for this. There is also third test case (`construct_uri_like_short_ipv4`), which passes without this fix but should prevent future regressions.
