### PR TITLE
Allow for building with the Android NDK.

### DIFF
--- a/src/network/uri/uri.hpp
+++ b/src/network/uri/uri.hpp
@@ -16,6 +16,7 @@
 #include <iterator>
 #include <algorithm>
 #include <functional>
+#include <boost/lexical_cast.hpp>
 #include <boost/utility/string_ref.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/optional.hpp>
@@ -266,10 +267,9 @@ namespace network {
     boost::optional<IntT> port(typename std::is_integral<IntT>::type * = 0) const {
       if (auto p = port()) {
         try {
-          return static_cast<IntT>(
-              std::stoi(string_type(std::begin(*p), std::end(*p))));
+          return boost::lexical_cast<IntT>(string_type(std::begin(*p), std::end(*p)));
         }
-        catch (std::invalid_argument &) {
+        catch (boost::bad_lexical_cast &) {
           return boost::optional<IntT>();
         }
       }

--- a/src/network/uri/uri_builder.hpp
+++ b/src/network/uri/uri_builder.hpp
@@ -71,7 +71,7 @@ namespace network {
     struct port_converter<T, typename std::enable_if<std::is_integral<typename std::decay<T>::type>::value>::type> {
 
       uri::string_type operator () (std::uint16_t port) const {
-	return std::to_string(port);
+	return boost::lexical_cast<uri::string_type>(port);
       }
 
     };


### PR DESCRIPTION
Use boost::lexical_cast instead of std::to_string and std::stoi functions - which aren't defined by android.

I'm not sure about the performance implications or the added dependency that comes with this change (boost::lexical_cast) - but it seems to be working pretty smoothly, and all the tests still pass.