### PR TITLE
fixes crash when debugging on xcode

### DIFF
--- a/src/detail/uri_parse.cpp
+++ b/src/detail/uri_parse.cpp
@@ -81,9 +81,8 @@ namespace network {
 
         ipvfuture %= qi::lit('v') >> +qi::xdigit >> '.' >>
                      +(unreserved | sub_delims | ':');
-
-        ipv6address %= qi::raw
-            [qi::repeat(6)[h16 >> ':'] >> ls32 |
+        
+        auto a = qi::repeat(6)[h16 >> ':'] >> ls32 |
              "::" >> qi::repeat(5)[h16 >> ':'] >> ls32 |
              -qi::raw[h16] >> "::" >> qi::repeat(4)[h16 >> ':'] >> ls32 |
              -qi::raw[h16] >> "::" >> qi::repeat(3)[h16 >> ':'] >> ls32 |
@@ -96,20 +95,23 @@ namespace network {
              -qi::raw[qi::repeat(1)[(h16 >> ':')] >> h16] >> "::" >>
                  qi::repeat(2)[h16 >> ':'] >> ls32 |
              -qi::raw[qi::repeat(1)[(h16 >> ':')] >> h16] >> "::" >> h16 >>
-                 ':' >> ls32 |
-             -qi::raw[qi::repeat(1)[(h16 >> ':')] >> h16] >> "::" >> ls32 |
+                 ':' >> ls32;
+                 
+        auto b =  -qi::raw[qi::repeat(1)[(h16 >> ':')] >> h16] >> "::" >> ls32 |
              -qi::raw[qi::repeat(1)[(h16 >> ':')] >> h16] >> "::" >> h16 |
              -qi::raw[qi::repeat(1)[(h16 >> ':')] >> h16] >> "::" |
              -qi::raw[qi::repeat(2)[(h16 >> ':')] >> h16] >> "::" >>
                  qi::repeat(2)[h16 >> ':'] >> ls32 |
              -qi::raw[qi::repeat(2)[(h16 >> ':')] >> h16] >> "::" >> h16 >>
-                 ':' >> ls32 |
-             -qi::raw[qi::repeat(2)[(h16 >> ':')] >> h16] >> "::" >> ls32 |
+                 ':' >> ls32;
+                 
+        auto c =  -qi::raw[qi::repeat(2)[(h16 >> ':')] >> h16] >> "::" >> ls32 |
              -qi::raw[qi::repeat(2)[(h16 >> ':')] >> h16] >> "::" >> h16 |
              -qi::raw[qi::repeat(2)[(h16 >> ':')] >> h16] >> "::" |
              -qi::raw[qi::repeat(3)[(h16 >> ':')] >> h16] >> "::" >> h16 >>
-                 ':' >> ls32 |
-             -qi::raw[qi::repeat(3)[(h16 >> ':')] >> h16] >> "::" >> ls32 |
+                 ':' >> ls32;
+
+        auto d =  -qi::raw[qi::repeat(3)[(h16 >> ':')] >> h16] >> "::" >> ls32 |
              -qi::raw[qi::repeat(3)[(h16 >> ':')] >> h16] >> "::" >> h16 |
              -qi::raw[qi::repeat(3)[(h16 >> ':')] >> h16] >> "::" |
              -qi::raw[qi::repeat(4)[(h16 >> ':')] >> h16] >> "::" >> ls32 |
@@ -117,8 +119,8 @@ namespace network {
              -qi::raw[qi::repeat(4)[(h16 >> ':')] >> h16] >> "::" |
              -qi::raw[qi::repeat(5)[(h16 >> ':')] >> h16] >> "::" >> h16 |
              -qi::raw[qi::repeat(5)[(h16 >> ':')] >> h16] >> "::" |
-             -qi::raw[qi::repeat(6)[(h16 >> ':')] >> h16] >> "::"];
-
+             -qi::raw[qi::repeat(6)[(h16 >> ':')] >> h16] >> "::";
+        ipv6address %= qi::raw[ a | b | c | d ];
         // ls32 = ( h16 ":" h16 ) / IPv4address
         ls32 %= (h16 >> ':' >> h16) | ipv4address;
 


### PR DESCRIPTION
when running an application using this library from within xcode, it'll crash xcode. dividing the code like it's done in this patch fixes it.

this is mostly an update of https://github.com/cpp-netlib/cpp-netlib/commit/f7c46adafb856b1bdff267fc2f454be1a5217c0b for the new structure of the repo and should also fix: https://github.com/cpp-netlib/cpp-netlib/issues/539