### PR TITLE
Fix #include guard

### DIFF
--- a/src/detail/uri_parse_authority.hpp
+++ b/src/detail/uri_parse_authority.hpp
@@ -4,8 +4,8 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 
-#ifndef NETWORK_DETAIL_URI_PARSE_INC
-#define NETWORK_DETAIL_URI_PARSE_INC
+#ifndef NETWORK_DETAIL_URI_PARSE_AUTHORITY_INC
+#define NETWORK_DETAIL_URI_PARSE_AUTHORITY_INC
 
 #include <network/uri/uri.hpp>
 
@@ -19,4 +19,4 @@ namespace network {
   } // namespace detail
 } // namespace network
 
-#endif // NETWORK_DETAIL_URI_PARSE_INC
+#endif // NETWORK_DETAIL_URI_PARSE_AUTHORITY_INC


### PR DESCRIPTION
This fixes the `#include` guard for `src/detail/uri_parse_authority.hpp`,
which, before this commit, uses the same `#include` guard definition as
`src/detail/uri_parse.hpp`. This commit gives `uri_parse_authority.hpp` a
unique guard definition.