### PR TITLE
Fix normalization regarding percent-encoded chars

### DIFF
--- a/src/detail/uri_normalize.cpp
+++ b/src/detail/uri_normalize.cpp
@@ -30,8 +30,8 @@ namespace network {
         boost::for_each(normalized, percent_encoded_to_upper());
 
         // % encoding normalization
-        normalized.erase(detail::decode_encoded_chars(std::begin(normalized),
-                                                      std::end(normalized)),
+        normalized.erase(detail::decode_encoded_unreserved_chars(std::begin(normalized),
+                                                                 std::end(normalized)),
                          std::end(normalized));
 
         // % path segment normalization

--- a/src/detail/uri_percent_encode.hpp
+++ b/src/detail/uri_percent_encode.hpp
@@ -67,6 +67,45 @@ namespace network {
       return it2;
     }
 
+    template <class Iter>
+    Iter decode_encoded_unreserved_chars(Iter first, Iter last) {
+
+      // unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
+
+      const auto is_unreserved = [](char c)
+      {
+        return std::isalnum(c)
+            || '-' == c
+            || '.' == c
+            || '_' == c
+            || '~' == c;
+      };
+
+      auto it = first, it2 = first;
+      while (it != last) {
+        if (*it == '%') {
+          const auto sfirst = it;
+          const auto slast = [&]() {
+            auto slast = it;
+            std::advance(slast, 3);
+            return slast;
+          }();
+          const auto opt_char = percent_encode(std::string(sfirst, slast));
+          if (opt_char && is_unreserved(*opt_char)) {
+            *it2 = *opt_char;
+            ++it; ++it;
+          } else {
+            *it2 = *it;
+          }
+        }
+        else {
+          *it2 = *it;
+        }
+        ++it; ++it2;
+      }
+      return it2;
+    }
+
   } // namespace detail
 } // namespace network
 

--- a/src/detail/uri_percent_encode.hpp
+++ b/src/detail/uri_percent_encode.hpp
@@ -47,27 +47,6 @@ namespace network {
     };
 
     template <class Iter>
-    Iter decode_encoded_chars(Iter first, Iter last) {
-      auto it = first, it2 = first;
-      while (it != last) {
-	if (*it == '%') {
-	  auto sfirst = it, slast = it;
-	  std::advance(slast, 3);
-	  auto opt_char = percent_encode(std::string(sfirst, slast));
-	  if (opt_char) {
-	    *it2 = *opt_char;
-	  }
-	  ++it; ++it;
-	}
-	else {
-	  *it2 = *it;
-	}
-	++it; ++it2;
-      }
-      return it2;
-    }
-
-    template <class Iter>
     Iter decode_encoded_unreserved_chars(Iter first, Iter last) {
 
       // unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"

--- a/src/uri.cpp
+++ b/src/uri.cpp
@@ -391,8 +391,8 @@ namespace network {
       // parts are invalidated here
       // there's got to be a better way of doing this that doesn't
       // mean parsing again (twice!)
-      normalized.erase(detail::decode_encoded_chars(std::begin(normalized),
-                                                    std::end(normalized)),
+      normalized.erase(detail::decode_encoded_unreserved_chars(std::begin(normalized),
+                                                               std::end(normalized)),
                        std::end(normalized));
 
       // need to parse the parts again as the underlying string has changed

--- a/test/uri_comparison_test.cpp
+++ b/test/uri_comparison_test.cpp
@@ -74,3 +74,16 @@ TEST(uri_comparison_test, less_than_test) {
   network::uri rhs("http://www.example.org/");
   ASSERT_LT(lhs, rhs);
 }
+
+TEST(uri_comparison_test, percent_encoded_query_reserved_chars) {
+  network::uri lhs("http://www.example.com?foo=%5cbar");
+  network::uri rhs("http://www.example.com?foo=%5Cbar");
+  ASSERT_EQ(lhs.compare(rhs, network::uri_comparison_level::syntax_based), 0);
+}
+
+
+TEST(uri_comparison_test, percent_encoded_query_unreserved_chars) {
+  network::uri lhs("http://www.example.com?foo=%61%6c%70%68%61%31%32%33%2d%2e%5f%7e");
+  network::uri rhs("http://www.example.com?foo=alpha123-._~");
+  ASSERT_EQ(lhs.compare(rhs, network::uri_comparison_level::syntax_based), 0);
+}

--- a/test/uri_normalization_test.cpp
+++ b/test/uri_normalization_test.cpp
@@ -146,6 +146,19 @@ TEST(uri_normalization_test, path_dash_dot_dash_dot) {
 	    instance.normalize(network::uri_comparison_level::syntax_based));
 }
 
+TEST(uri_normalization_test, path_percent_encoded_reserved) {
+  // :/?#[]@!$&'()*+,;=
+  network::uri instance("http://www.example.com/%3a%2f%3f%23%5b%5d%40%21%24%26%27%28%29%2a%2b%2c%3b%3d");
+  ASSERT_EQ("http://www.example.com/%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D",
+        instance.normalize(network::uri_comparison_level::syntax_based));
+}
+
+TEST(uri_normalization_test, path_percent_encoded_unreserved) {
+  network::uri instance("http://www.example.com/alpha123%2d%2e%5f%7e");
+  ASSERT_EQ("http://www.example.com/alpha123-._~",
+        instance.normalize(network::uri_comparison_level::syntax_based));
+}
+
 TEST(uri_normalization_test, query_percent_encoded_reserved) {
   // :/?#[]@!$&'()*+,;=
   network::uri instance("http://www.example.com?foo=%3a%2f%3f%23%5b%5d%40%21%24%26%27%28%29%2a%2b%2c%3b%3d");

--- a/test/uri_normalization_test.cpp
+++ b/test/uri_normalization_test.cpp
@@ -145,3 +145,16 @@ TEST(uri_normalization_test, path_dash_dot_dash_dot) {
   ASSERT_EQ("http://www.example.com/",
 	    instance.normalize(network::uri_comparison_level::syntax_based));
 }
+
+TEST(uri_normalization_test, query_percent_encoded_reserved) {
+  // :/?#[]@!$&'()*+,;=
+  network::uri instance("http://www.example.com?foo=%3a%2f%3f%23%5b%5d%40%21%24%26%27%28%29%2a%2b%2c%3b%3d");
+  ASSERT_EQ("http://www.example.com/?foo=%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D",
+        instance.normalize(network::uri_comparison_level::syntax_based));
+}
+
+TEST(uri_normalization_test, query_percent_encoded_unreserved) {
+  network::uri instance("http://www.example.com?foo=alpha123%2d%2e%5f%7e");
+  ASSERT_EQ("http://www.example.com/?foo=alpha123-._~",
+        instance.normalize(network::uri_comparison_level::syntax_based));
+}


### PR DESCRIPTION
Fix syntax-based normalization to percent-decode unreserved characters only, leaving all other percent-encoded characters unchanged.

This commit resolves issue #70.