### PR TITLE
Replaced the accessors that return optional string_view objects with two separate functions.

### DIFF
--- a/src/detail/uri_resolve.cpp
+++ b/src/detail/uri_resolve.cpp
@@ -65,15 +65,15 @@ uri::string_type remove_dot_segments(uri::string_view path) {
 uri::string_type merge_paths(const uri& base, const uri& reference) {
   uri::string_type result;
 
-  if (!base.path() || base.path()->empty()) {
+  if (!base.has_path() || base.path().empty()) {
     result = "/";
   } else {
-    const auto& base_path = base.path().value();
+    const auto& base_path = base.path();
     auto last_slash = network_boost::find_last(base_path, "/");
     result.append(std::begin(base_path), std::end(last_slash));
   }
-  if (reference.path()) {
-    result.append(reference.path()->to_string());
+  if (reference.has_path()) {
+    result.append(reference.path().to_string());
   }
   return remove_dot_segments(std::move(result));
 }

--- a/src/network/uri/uri.hpp
+++ b/src/network/uri/uri.hpp
@@ -205,66 +205,66 @@ class uri {
    *        underlying sequence.
    * \return An iterator starting at the first element.
    */
-  const_iterator begin() const;
+  const_iterator begin() const noexcept;
 
   /**
    * \brief Returns an iterator at the end + 1th element in the
    *        underlying sequence.
    * \return An iterator starting at the end + 1th element.
    */
-  const_iterator end() const;
+  const_iterator end() const noexcept;
 
   /**
    * \brief Tests whether this URI has a scheme component.
    * \return \c true if the URI has a scheme, \c false otherwise.
    */
-  bool has_scheme() const;
+  bool has_scheme() const noexcept;
 
   /**
    * \brief Returns the URI scheme.
    * \return The scheme.
    * \pre has_scheme()
    */
-  string_view scheme() const;
+  string_view scheme() const noexcept;
 
   /**
    * \brief Tests whether this URI has a user info component.
    * \return \c true if the URI has a user info, \c false otherwise.
    */
-  bool has_user_info() const;
+  bool has_user_info() const noexcept;
 
   /**
    * \brief Returns the URI user info.
    * \return The user info.
    * \pre has_user_info()
    */
-  string_view user_info() const;
+  string_view user_info() const noexcept;
 
   /**
    * \brief Tests whether this URI has a host component.
    * \return \c true if the URI has a host, \c false otherwise.
    */
-  bool has_host() const;
+  bool has_host() const noexcept;
 
   /**
    * \brief Returns the URI host.
    * \return The host.
    * \pre has_host()
    */
-  string_view host() const;
+  string_view host() const noexcept;
 
   /**
    * \brief Tests whether this URI has a port component.
    * \return \c true if the URI has a port, \c false otherwise.
    */
-  bool has_port() const;
+  bool has_port() const noexcept;
 
   /**
    * \brief Returns the URI port.
    * \return The port.
    * \pre has_port()
    */
-  string_view port() const;
+  string_view port() const noexcept;
 
   /**
    * \brief Returns the URI port as an integer.
@@ -288,52 +288,52 @@ class uri {
    * \brief Tests whether this URI has a path component.
    * \return \c true if the URI has a path, \c false otherwise.
    */
-  bool has_path() const;
+  bool has_path() const noexcept;
 
   /**
    * \brief Returns the URI path.
    * \return The path.
    * \pre has_path()
    */
-  string_view path() const;
+  string_view path() const noexcept;
 
   /**
    * \brief Tests whether this URI has a query component.
    * \return \c true if the URI has a query, \c false otherwise.
    */
-  bool has_query() const;
+  bool has_query() const noexcept;
 
   /**
    * \brief Returns the URI query.
    * \return The query.
    * \pre has_query()
    */
-  string_view query() const;
+  string_view query() const noexcept;
 
   /**
    * \brief Tests whether this URI has a fragment component.
    * \return \c true if the URI has a fragment, \c false otherwise.
    */
-  bool has_fragment() const;
+  bool has_fragment() const noexcept;
 
   /**
    * \brief Returns the URI fragment.
    * \return The fragment.
    * \pre has_fragment()
    */
-  string_view fragment() const;
+  string_view fragment() const noexcept;
 
   /**
    * \brief Tests whether this URI has a valid authority.
    * \return \c true if the URI has an authority, \c false otherwise.
    */
-  bool has_authority() const;
+  bool has_authority() const noexcept;
 
   /**
    * \brief Returns the URI authority.
    * \return The authority.
    */
-  string_view authority() const;
+  string_view authority() const noexcept;
 
 #if !defined(NETWORK_URI_MSVC)
   /**
@@ -390,14 +390,14 @@ class uri {
    * \brief Checks if the uri is absolute, i.e. it has a scheme.
    * \returns \c true if it is absolute, \c false if it is relative.
    */
-  bool is_absolute() const;
+  bool is_absolute() const noexcept;
 
   /**
    * \brief Checks if the uri is opaque, i.e. if it doesn't have an
    *        authority.
    * \returns \c true if it is opaque, \c false if it is hierarchical.
    */
-  bool is_opaque() const;
+  bool is_opaque() const noexcept;
 
   /**
    * \brief Normalizes a uri object at a given level in the

--- a/src/network/uri/uri.hpp
+++ b/src/network/uri/uri.hpp
@@ -119,7 +119,7 @@ class uri {
 
  public:
   /**
-   * \brief Constructor.
+   * \brief Default constructor.
    */
   uri();
 
@@ -215,68 +215,125 @@ class uri {
   const_iterator end() const;
 
   /**
-   * \brief Returns the URI scheme.
-   * \return The scheme, if it exists, or nullopt.
+   * \brief Tests whether this URI has a scheme component.
+   * \return \c true if the URI has a scheme, \c false otherwise.
    */
-  optional<string_view> scheme() const;
+  bool has_scheme() const;
+
+  /**
+   * \brief Returns the URI scheme.
+   * \return The scheme.
+   * \pre has_scheme()
+   */
+  string_view scheme() const;
+
+  /**
+   * \brief Tests whether this URI has a user info component.
+   * \return \c true if the URI has a user info, \c false otherwise.
+   */
+  bool has_user_info() const;
 
   /**
    * \brief Returns the URI user info.
-   * \return The user info, if it exists, or nullopt.
+   * \return The user info.
+   * \pre has_user_info()
    */
-  optional<string_view> user_info() const;
+  string_view user_info() const;
+
+  /**
+   * \brief Tests whether this URI has a host component.
+   * \return \c true if the URI has a host, \c false otherwise.
+   */
+  bool has_host() const;
 
   /**
    * \brief Returns the URI host.
-   * \return The host, if it exists, or nullopt.
+   * \return The host.
+   * \pre has_host()
    */
-  optional<string_view> host() const;
+  string_view host() const;
+
+  /**
+   * \brief Tests whether this URI has a port component.
+   * \return \c true if the URI has a port, \c false otherwise.
+   */
+  bool has_port() const;
 
   /**
    * \brief Returns the URI port.
-   * \return The port, if it exists, or nullopt.
+   * \return The port.
+   * \pre has_port()
    */
-  optional<string_view> port() const;
+  string_view port() const;
 
   /**
    * \brief Returns the URI port as an integer.
-   * \return The port, if it exists, or nullopt.
+   * \return The port number.
+   * \pre has_port()
    */
   template <typename IntT>
-  optional<IntT> port(typename std::is_integral<IntT>::type * = 0) const {
-    if (auto p = port()) {
-      try {
-        return std::stoi(string_type(std::begin(*p), std::end(*p)));
-      } catch (std::exception &) {
-        return optional<IntT>();
-      }
+  IntT port(typename std::is_integral<IntT>::type * = 0) const {
+    assert(has_port());
+
+    auto p = port();
+    try {
+      return std::stoi(port().to_string());
     }
-    return optional<IntT>();
+    catch (std::exception &) {
+      assert(!"Unable to parse port number.");
+    }
   }
 
   /**
-   * \brief Returns the URI path.
-   * \return The path, if it exists, or nullopt.
+   * \brief Tests whether this URI has a path component.
+   * \return \c true if the URI has a path, \c false otherwise.
    */
-  optional<string_view> path() const;
+  bool has_path() const;
+
+  /**
+   * \brief Returns the URI path.
+   * \return The path.
+   * \pre has_path()
+   */
+  string_view path() const;
+
+  /**
+   * \brief Tests whether this URI has a query component.
+   * \return \c true if the URI has a query, \c false otherwise.
+   */
+  bool has_query() const;
 
   /**
    * \brief Returns the URI query.
-   * \return The query, if it exists, or nullopt.
+   * \return The query.
+   * \pre has_query()
    */
-  optional<string_view> query() const;
+  string_view query() const;
+
+  /**
+   * \brief Tests whether this URI has a fragment component.
+   * \return \c true if the URI has a fragment, \c false otherwise.
+   */
+  bool has_fragment() const;
 
   /**
    * \brief Returns the URI fragment.
-   * \return The fragment, if it exists, or nullopt.
+   * \return The fragment.
+   * \pre has_fragment()
    */
-  optional<string_view> fragment() const;
+  string_view fragment() const;
+
+  /**
+   * \brief Tests whether this URI has a valid authority.
+   * \return \c true if the URI has an authority, \c false otherwise.
+   */
+  bool has_authority() const;
 
   /**
    * \brief Returns the URI authority.
-   * \return The authority, if it exists, or nullopt.
+   * \return The authority.
    */
-  optional<string_view> authority() const;
+  string_view authority() const;
 
 #if !defined(NETWORK_URI_MSVC)
   /**

--- a/src/uri.cpp
+++ b/src/uri.cpp
@@ -223,9 +223,9 @@ void uri::swap(uri &other) noexcept {
   advance_parts(other.uri_, *other.uri_parts_, *uri_parts_);
 }
 
-uri::const_iterator uri::begin() const { return uri_view_.begin(); }
+uri::const_iterator uri::begin() const noexcept { return uri_view_.begin(); }
 
-uri::const_iterator uri::end() const { return uri_view_.end(); }
+uri::const_iterator uri::end() const noexcept { return uri_view_.end(); }
 
 namespace {
 inline uri::string_view to_string_view(const uri::string_type &uri,
@@ -247,74 +247,74 @@ inline uri::string_view to_string_view(
 }
 }  // namespace
 
-bool uri::has_scheme() const {
+bool uri::has_scheme() const noexcept {
   return static_cast<bool>(uri_parts_->scheme);
 }
 
-uri::string_view uri::scheme() const {
+uri::string_view uri::scheme() const noexcept {
   assert(has_scheme());
   return to_string_view(uri_, *uri_parts_->scheme);
 }
 
-bool uri::has_user_info() const {
+bool uri::has_user_info() const noexcept {
   return static_cast<bool>(uri_parts_->hier_part.user_info);
 }
 
-uri::string_view uri::user_info() const {
+uri::string_view uri::user_info() const noexcept {
   assert(has_user_info());
   return to_string_view(uri_, *uri_parts_->hier_part.user_info);
 }
 
-bool uri::has_host() const {
+bool uri::has_host() const noexcept {
   return static_cast<bool>(uri_parts_->hier_part.host);
 }
 
-uri::string_view uri::host() const {
+uri::string_view uri::host() const noexcept {
   assert(has_host());
   return to_string_view(uri_, *uri_parts_->hier_part.host);
 }
 
-bool uri::has_port() const {
+bool uri::has_port() const noexcept {
   return static_cast<bool>(uri_parts_->hier_part.port);
 }
 
-uri::string_view uri::port() const {
+uri::string_view uri::port() const noexcept {
   assert(has_port());
   return to_string_view(uri_, *uri_parts_->hier_part.port);
 }
 
-bool uri::has_path() const {
+bool uri::has_path() const noexcept {
   return static_cast<bool>(uri_parts_->hier_part.path);
 }
 
-uri::string_view uri::path() const {
+uri::string_view uri::path() const noexcept {
   assert(has_path());
   return to_string_view(uri_, *uri_parts_->hier_part.path);
 }
 
-bool uri::has_query() const {
+bool uri::has_query() const noexcept {
   return static_cast<bool>(uri_parts_->query);
 }
 
-uri::string_view uri::query() const {
+uri::string_view uri::query() const noexcept {
   assert(has_query());
   return to_string_view(uri_, *uri_parts_->query);
 }
 
-bool uri::has_fragment() const {
+bool uri::has_fragment() const noexcept {
   return static_cast<bool>(uri_parts_->fragment);
 }
 
-uri::string_view uri::fragment() const {
+uri::string_view uri::fragment() const noexcept {
   assert(has_fragment());
   return to_string_view(uri_, *uri_parts_->fragment);
 }
 
-bool uri::has_authority() const {
+bool uri::has_authority() const noexcept {
   return has_host();
 }
 
-uri::string_view uri::authority() const {
+uri::string_view uri::authority() const noexcept {
   assert(has_host());
   auto host = this->host();
 
@@ -374,9 +374,11 @@ std::u32string uri::u32string() const {
 
 bool uri::empty() const noexcept { return uri_.empty(); }
 
-bool uri::is_absolute() const { return has_scheme(); }
+bool uri::is_absolute() const noexcept { return has_scheme(); }
 
-bool uri::is_opaque() const { return (is_absolute() && !has_authority()); }
+bool uri::is_opaque() const noexcept {
+  return (is_absolute() && !has_authority());
+}
 
 uri uri::normalize(uri_comparison_level level) const {
   string_type normalized(uri_);

--- a/src/uri.cpp
+++ b/src/uri.cpp
@@ -252,8 +252,8 @@ bool uri::has_scheme() const noexcept {
 }
 
 uri::string_view uri::scheme() const noexcept {
-  assert(has_scheme());
-  return to_string_view(uri_, *uri_parts_->scheme);
+  return has_scheme() ? to_string_view(uri_, *uri_parts_->scheme)
+                      : string_view{};
 }
 
 bool uri::has_user_info() const noexcept {
@@ -261,8 +261,9 @@ bool uri::has_user_info() const noexcept {
 }
 
 uri::string_view uri::user_info() const noexcept {
-  assert(has_user_info());
-  return to_string_view(uri_, *uri_parts_->hier_part.user_info);
+  return has_user_info()
+             ? to_string_view(uri_, *uri_parts_->hier_part.user_info)
+             : string_view{};
 }
 
 bool uri::has_host() const noexcept {
@@ -270,8 +271,8 @@ bool uri::has_host() const noexcept {
 }
 
 uri::string_view uri::host() const noexcept {
-  assert(has_host());
-  return to_string_view(uri_, *uri_parts_->hier_part.host);
+  return has_host() ? to_string_view(uri_, *uri_parts_->hier_part.host)
+                    : string_view{};
 }
 
 bool uri::has_port() const noexcept {
@@ -279,8 +280,8 @@ bool uri::has_port() const noexcept {
 }
 
 uri::string_view uri::port() const noexcept {
-  assert(has_port());
-  return to_string_view(uri_, *uri_parts_->hier_part.port);
+  return has_port() ? to_string_view(uri_, *uri_parts_->hier_part.port)
+                    : string_view{};
 }
 
 bool uri::has_path() const noexcept {
@@ -288,8 +289,8 @@ bool uri::has_path() const noexcept {
 }
 
 uri::string_view uri::path() const noexcept {
-  assert(has_path());
-  return to_string_view(uri_, *uri_parts_->hier_part.path);
+  return has_path() ? to_string_view(uri_, *uri_parts_->hier_part.path)
+                    : string_view{};
 }
 
 bool uri::has_query() const noexcept {
@@ -297,8 +298,7 @@ bool uri::has_query() const noexcept {
 }
 
 uri::string_view uri::query() const noexcept {
-  assert(has_query());
-  return to_string_view(uri_, *uri_parts_->query);
+  return has_query() ? to_string_view(uri_, *uri_parts_->query) : string_view{};
 }
 
 bool uri::has_fragment() const noexcept {
@@ -306,8 +306,8 @@ bool uri::has_fragment() const noexcept {
 }
 
 uri::string_view uri::fragment() const noexcept {
-  assert(has_fragment());
-  return to_string_view(uri_, *uri_parts_->fragment);
+  return has_fragment() ? to_string_view(uri_, *uri_parts_->fragment)
+                        : string_view{};
 }
 
 bool uri::has_authority() const noexcept {
@@ -315,7 +315,10 @@ bool uri::has_authority() const noexcept {
 }
 
 uri::string_view uri::authority() const noexcept {
-  assert(has_host());
+  if (!has_host()) {
+    return string_view{};
+  }
+
   auto host = this->host();
 
   auto user_info = string_view{};

--- a/src/uri_builder.cpp
+++ b/src/uri_builder.cpp
@@ -10,32 +10,32 @@
 
 namespace network {
 uri_builder::uri_builder(const network::uri &base_uri) {
-  if (auto scheme = base_uri.scheme()) {
-    set_scheme(string_type(std::begin(*scheme), std::end(*scheme)));
+  if (base_uri.has_scheme()) {
+    set_scheme(base_uri.scheme().to_string());
   }
 
-  if (auto user_info = base_uri.user_info()) {
-    set_user_info(string_type(std::begin(*user_info), std::end(*user_info)));
+  if (base_uri.has_user_info()) {
+    set_user_info(base_uri.user_info().to_string());
   }
 
-  if (auto host = base_uri.host()) {
-    set_host(string_type(std::begin(*host), std::end(*host)));
+  if (base_uri.has_host()) {
+    set_host(base_uri.host().to_string());
   }
 
-  if (auto port = base_uri.port()) {
-    set_port(string_type(std::begin(*port), std::end(*port)));
+  if (base_uri.has_port()) {
+    set_port(base_uri.port().to_string());
   }
 
-  if (auto path = base_uri.path()) {
-    set_path(string_type(std::begin(*path), std::end(*path)));
+  if (base_uri.has_path()) {
+    set_path(base_uri.path().to_string());
   }
 
-  if (auto query = base_uri.query()) {
-    set_query(string_type(std::begin(*query), std::end(*query)));
+  if (base_uri.has_query()) {
+    set_query(base_uri.query().to_string());
   }
 
-  if (auto fragment = base_uri.fragment()) {
-    set_fragment(string_type(std::begin(*fragment), std::end(*fragment)));
+  if (base_uri.has_fragment()) {
+    set_fragment(base_uri.fragment().to_string());
   }
 }
 

--- a/test/uri_builder_test.cpp
+++ b/test/uri_builder_test.cpp
@@ -46,7 +46,7 @@ TEST(builder_test, simple_uri_has_scheme) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_TRUE(static_cast<bool>(builder.uri().scheme()));
+  ASSERT_TRUE(builder.uri().has_scheme());
 }
 
 TEST(builder_test, simple_uri_scheme_value) {
@@ -56,7 +56,7 @@ TEST(builder_test, simple_uri_scheme_value) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_EQ("http", *builder.uri().scheme());
+  ASSERT_EQ("http", builder.uri().scheme());
 }
 
 TEST(builder_test, simple_uri_has_no_user_info) {
@@ -66,7 +66,7 @@ TEST(builder_test, simple_uri_has_no_user_info) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_FALSE(builder.uri().user_info());
+  ASSERT_FALSE(builder.uri().has_user_info());
 }
 
 TEST(builder_test, simple_uri_has_host) {
@@ -76,7 +76,7 @@ TEST(builder_test, simple_uri_has_host) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_TRUE(static_cast<bool>(builder.uri().host()));
+  ASSERT_TRUE(builder.uri().has_host());
 }
 
 TEST(builder_test, simple_uri_host_value) {
@@ -86,7 +86,7 @@ TEST(builder_test, simple_uri_host_value) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_EQ("www.example.com", *builder.uri().host());
+  ASSERT_EQ("www.example.com", builder.uri().host());
 }
 
 TEST(builder_test, simple_uri_has_no_port) {
@@ -96,7 +96,7 @@ TEST(builder_test, simple_uri_has_no_port) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_FALSE(builder.uri().port());
+  ASSERT_FALSE(builder.uri().has_port());
 }
 
 TEST(builder_test, simple_uri_has_path) {
@@ -106,7 +106,7 @@ TEST(builder_test, simple_uri_has_path) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_TRUE(static_cast<bool>(builder.uri().path()));
+  ASSERT_TRUE(builder.uri().has_path());
 }
 
 TEST(builder_test, simple_uri_path_value) {
@@ -116,7 +116,7 @@ TEST(builder_test, simple_uri_path_value) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_EQ("/", *builder.uri().path());
+  ASSERT_EQ("/", builder.uri().path());
 }
 
 TEST(builder_test, simple_uri_has_no_query) {
@@ -126,7 +126,7 @@ TEST(builder_test, simple_uri_has_no_query) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_FALSE(builder.uri().query());
+  ASSERT_FALSE(builder.uri().has_query());
 }
 
 TEST(builder_test, simple_uri_has_no_fragment) {
@@ -136,7 +136,7 @@ TEST(builder_test, simple_uri_has_no_fragment) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_FALSE(builder.uri().fragment());
+  ASSERT_FALSE(builder.uri().has_fragment());
 }
 
 TEST(builder_test, simple_opaque_uri_doesnt_throw) {
@@ -163,7 +163,7 @@ TEST(builder_test, simple_opaque_uri_has_scheme) {
     .scheme("mailto")
     .path("john.doe@example.com")
     ;
-  ASSERT_TRUE(static_cast<bool>(builder.uri().scheme()));
+  ASSERT_TRUE(builder.uri().has_scheme());
 }
 
 TEST(builder_test, simple_opaque_uri_scheme_value) {
@@ -172,7 +172,7 @@ TEST(builder_test, simple_opaque_uri_scheme_value) {
     .scheme("mailto")
     .path("john.doe@example.com")
     ;
-  ASSERT_EQ("mailto", *builder.uri().scheme());
+  ASSERT_EQ("mailto", builder.uri().scheme());
 }
 
 TEST(builder_test, relative_hierarchical_uri_doesnt_throw) {
@@ -248,7 +248,7 @@ TEST(builder_test, full_uri_has_scheme) {
     .query("query")
     .fragment("fragment")
     ;
-  ASSERT_TRUE(static_cast<bool>(builder.uri().scheme()));
+  ASSERT_TRUE(builder.uri().has_scheme());
 }
 
 TEST(builder_test, full_uri_scheme_value) {
@@ -262,7 +262,7 @@ TEST(builder_test, full_uri_scheme_value) {
     .query("query")
     .fragment("fragment")
     ;
-  ASSERT_EQ("http", *builder.uri().scheme());
+  ASSERT_EQ("http", builder.uri().scheme());
 }
 
 TEST(builder_test, full_uri_has_user_info) {
@@ -276,7 +276,7 @@ TEST(builder_test, full_uri_has_user_info) {
     .query("query")
     .fragment("fragment")
     ;
-  ASSERT_TRUE(static_cast<bool>(builder.uri().user_info()));
+  ASSERT_TRUE(builder.uri().has_user_info());
 }
 
 TEST(builder_test, full_uri_user_info_value) {
@@ -290,7 +290,7 @@ TEST(builder_test, full_uri_user_info_value) {
     .query("query")
     .fragment("fragment")
     ;
-  ASSERT_EQ("user:password", *builder.uri().user_info());
+  ASSERT_EQ("user:password", builder.uri().user_info());
 }
 
 TEST(builder_test, full_uri_has_host) {
@@ -304,7 +304,7 @@ TEST(builder_test, full_uri_has_host) {
     .query("query")
     .fragment("fragment")
     ;
-  ASSERT_TRUE(static_cast<bool>(builder.uri().host()));
+  ASSERT_TRUE(builder.uri().has_host());
 }
 
 TEST(builder_test, full_uri_host_value) {
@@ -318,7 +318,7 @@ TEST(builder_test, full_uri_host_value) {
     .query("query")
     .fragment("fragment")
     ;
-  ASSERT_EQ("www.example.com", *builder.uri().host());
+  ASSERT_EQ("www.example.com", builder.uri().host());
 }
 
 TEST(builder_test, full_uri_has_port) {
@@ -332,7 +332,7 @@ TEST(builder_test, full_uri_has_port) {
     .query("query")
     .fragment("fragment")
     ;
-  ASSERT_TRUE(static_cast<bool>(builder.uri().port()));
+  ASSERT_TRUE(builder.uri().has_port());
 }
 
 TEST(builder_test, full_uri_has_path) {
@@ -346,7 +346,7 @@ TEST(builder_test, full_uri_has_path) {
     .query("query")
     .fragment("fragment")
     ;
-  ASSERT_TRUE(static_cast<bool>(builder.uri().path()));
+  ASSERT_TRUE(builder.uri().has_path());
 }
 
 TEST(builder_test, full_uri_path_value) {
@@ -360,7 +360,7 @@ TEST(builder_test, full_uri_path_value) {
     .query("query")
     .fragment("fragment")
     ;
-  ASSERT_EQ("/path", *builder.uri().path());
+  ASSERT_EQ("/path", builder.uri().path());
 }
 
 TEST(builder_test, full_uri_has_query) {
@@ -374,7 +374,7 @@ TEST(builder_test, full_uri_has_query) {
     .query("query")
     .fragment("fragment")
     ;
-  ASSERT_TRUE(static_cast<bool>(builder.uri().query()));
+  ASSERT_TRUE(builder.uri().has_query());
 }
 
 TEST(builder_test, full_uri_query_value) {
@@ -388,7 +388,7 @@ TEST(builder_test, full_uri_query_value) {
     .query("query")
     .fragment("fragment")
     ;
-  ASSERT_EQ("query", *builder.uri().query());
+  ASSERT_EQ("query", builder.uri().query());
 }
 
 TEST(builder_test, full_uri_has_fragment) {
@@ -402,7 +402,7 @@ TEST(builder_test, full_uri_has_fragment) {
     .query("query")
     .fragment("fragment")
     ;
-  ASSERT_TRUE(static_cast<bool>(builder.uri().fragment()));
+  ASSERT_TRUE(builder.uri().has_fragment());
 }
 
 TEST(builder_test, full_uri_fragment_value) {
@@ -416,7 +416,7 @@ TEST(builder_test, full_uri_fragment_value) {
     .query("query")
     .fragment("fragment")
     ;
-  ASSERT_EQ("fragment", *builder.uri().fragment());
+  ASSERT_EQ("fragment", builder.uri().fragment());
 }
 
 TEST(builder_test, relative_uri) {
@@ -434,7 +434,7 @@ TEST(builder_test, relative_uri_scheme) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_FALSE(builder.uri().scheme());
+  ASSERT_FALSE(builder.uri().has_scheme());
 }
 
 TEST(builder_test, authority) {
@@ -445,8 +445,8 @@ TEST(builder_test, authority) {
     .path("/")
     ;
   ASSERT_EQ("http://www.example.com:8080/", builder.uri());
-  ASSERT_EQ("www.example.com", *builder.uri().host());
-  ASSERT_EQ("8080", *builder.uri().port());
+  ASSERT_EQ("www.example.com", builder.uri().host());
+  ASSERT_EQ("8080", builder.uri().port());
 }
 
 TEST(builder_test, relative_uri_has_host) {
@@ -455,7 +455,7 @@ TEST(builder_test, relative_uri_has_host) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_TRUE(static_cast<bool>(builder.uri().host()));
+  ASSERT_TRUE(builder.uri().has_host());
 }
 
 TEST(builder_test, relative_uri_host_value) {
@@ -464,7 +464,7 @@ TEST(builder_test, relative_uri_host_value) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_EQ("www.example.com", *builder.uri().host());
+  ASSERT_EQ("www.example.com", builder.uri().host());
 }
 
 TEST(builder_test, relative_uri_has_path) {
@@ -473,7 +473,7 @@ TEST(builder_test, relative_uri_has_path) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_TRUE(static_cast<bool>(builder.uri().path()));
+  ASSERT_TRUE(builder.uri().has_path());
 }
 
 TEST(builder_test, relative_uri_path_value) {
@@ -482,7 +482,7 @@ TEST(builder_test, relative_uri_path_value) {
     .host("www.example.com")
     .path("/")
     ;
-  ASSERT_EQ("/", *builder.uri().path());
+  ASSERT_EQ("/", builder.uri().path());
 }
 
 TEST(builder_test, build_relative_uri_with_path_query_and_fragment) {
@@ -492,9 +492,9 @@ TEST(builder_test, build_relative_uri_with_path_query_and_fragment) {
     .query("key", "value")
     .fragment("fragment")
     ;
-  ASSERT_EQ("/path/", *builder.uri().path());
-  ASSERT_EQ("key=value", *builder.uri().query());
-  ASSERT_EQ("fragment", *builder.uri().fragment());
+  ASSERT_EQ("/path/", builder.uri().path());
+  ASSERT_EQ("key=value", builder.uri().query());
+  ASSERT_EQ("fragment", builder.uri().fragment());
 }
 
 TEST(builder_test, build_uri_with_capital_scheme) {
@@ -646,7 +646,7 @@ TEST(builder_test, authority_without_port_test) {
     .scheme("https")
     .authority("www.example.com")
     ;
-  ASSERT_EQ("www.example.com", *builder.uri().authority());
+  ASSERT_EQ("www.example.com", builder.uri().authority());
 }
 
 TEST(builder_test, authority_with_port_test) {
@@ -655,7 +655,7 @@ TEST(builder_test, authority_with_port_test) {
     .scheme("https")
     .authority("www.example.com:")
     ;
-  ASSERT_EQ("www.example.com:", *builder.uri().authority());
+  ASSERT_EQ("www.example.com:", builder.uri().authority());
 }
 
 TEST(builder_test, authority_without_host_test) {
@@ -664,7 +664,7 @@ TEST(builder_test, authority_without_host_test) {
     .scheme("https")
     .authority(":1234")
     ;
-  ASSERT_EQ(":1234", *builder.uri().authority());
+  ASSERT_EQ(":1234", builder.uri().authority());
 }
 
 TEST(builder_test, clear_user_info_test) {
@@ -720,5 +720,5 @@ TEST(builder_test, path_should_be_prefixed_with_slash_2) {
   network::uri_builder builder;
   builder
     .scheme("ftp").host("127.0.0.1").path("noleadingslash/foo.txt");
-  ASSERT_EQ("/noleadingslash/foo.txt", *builder.uri().path());
+  ASSERT_EQ("/noleadingslash/foo.txt", builder.uri().path());
 }

--- a/test/uri_resolve_test.cpp
+++ b/test/uri_resolve_test.cpp
@@ -291,9 +291,9 @@ TEST_F(uri_resolve_test, issue_15_resolve_from_copy_with_query) {
   network::uri copy = uri;
   ASSERT_TRUE(copy.is_opaque());
   auto result = copy.resolve(base);
-  ASSERT_EQ("query", *uri.query());
-  ASSERT_EQ("query", *copy.query());
-  ASSERT_EQ("query", *result.query());
+  ASSERT_EQ("query", uri.query());
+  ASSERT_EQ("query", copy.query());
+  ASSERT_EQ("query", result.query());
 }
 
 TEST_F(uri_resolve_test, issue_15_resolve_from_copy_with_fragment) {
@@ -303,5 +303,5 @@ TEST_F(uri_resolve_test, issue_15_resolve_from_copy_with_fragment) {
   network::uri copy = uri;
   ASSERT_TRUE(copy.is_opaque());
   auto result = copy.resolve(base);
-  ASSERT_EQ("fragment", *result.fragment());
+  ASSERT_EQ("fragment", result.fragment());
 }

--- a/test/uri_test.cpp
+++ b/test/uri_test.cpp
@@ -78,45 +78,40 @@ TEST(uri_test, make_uri_from_wstring) {
 
 TEST(uri_test, basic_uri_scheme_test) {
   network::uri instance("http://www.example.com/");
-  ASSERT_TRUE(static_cast<bool>(instance.scheme()));
-  ASSERT_EQ("http", *instance.scheme());
+  ASSERT_TRUE(instance.has_scheme());
+  ASSERT_EQ("http", instance.scheme());
 }
 
 TEST(uri_test, basic_uri_user_info_test) {
   network::uri instance("http://www.example.com/");
-  ASSERT_FALSE(instance.user_info());
+  ASSERT_FALSE(instance.has_user_info());
 }
 
 TEST(uri_test, basic_uri_host_test) {
   network::uri instance("http://www.example.com/");
-  ASSERT_TRUE(static_cast<bool>(instance.host()));
-  ASSERT_EQ("www.example.com", *instance.host());
+  ASSERT_TRUE(instance.has_host());
+  ASSERT_EQ("www.example.com", instance.host());
 }
 
 TEST(uri_test, basic_uri_port_test) {
   network::uri instance("http://www.example.com/");
-  ASSERT_FALSE(instance.port());
-}
-
-TEST(uri_test, basic_uri_port_as_int_test) {
-  network::uri instance("http://www.example.com/");
-  ASSERT_FALSE(instance.port<int>());
+  ASSERT_FALSE(instance.has_port());
 }
 
 TEST(uri_test, basic_uri_path_test) {
   network::uri instance("http://www.example.com/");
-  ASSERT_TRUE(static_cast<bool>(instance.path()));
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_TRUE(instance.has_path());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, basic_uri_query_test) {
   network::uri instance("http://www.example.com/");
-  ASSERT_FALSE(instance.query());
+  ASSERT_FALSE(instance.has_query());
 }
 
 TEST(uri_test, basic_uri_fragment_test) {
   network::uri instance("http://www.example.com/");
-  ASSERT_FALSE(instance.fragment());
+  ASSERT_FALSE(instance.has_fragment());
 }
 
 TEST(uri_test, basic_uri_value_semantics_test) {
@@ -132,277 +127,277 @@ TEST(uri_test, basic_uri_value_semantics_test) {
 
 TEST(uri_test, full_uri_scheme_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_EQ("http", *instance.scheme());
+  ASSERT_EQ("http", instance.scheme());
 }
 
 TEST(uri_test, full_uri_user_info_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_EQ("user:password", *instance.user_info());
+  ASSERT_EQ("user:password", instance.user_info());
 }
 
 TEST(uri_test, full_uri_host_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_EQ("www.example.com", *instance.host());
+  ASSERT_EQ("www.example.com", instance.host());
 }
 
 TEST(uri_test, full_uri_port_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_EQ("80", *instance.port());
+  ASSERT_EQ("80", instance.port());
 }
 
 TEST(uri_test, full_uri_port_as_int_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_EQ(80, *instance.port<int>());
+  ASSERT_EQ(80, instance.port<int>());
 }
 
 TEST(uri_test, full_uri_path_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_EQ("/path", *instance.path());
+  ASSERT_EQ("/path", instance.path());
 }
 
 TEST(uri_test, full_uri_query_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_EQ("query", *instance.query());
+  ASSERT_EQ("query", instance.query());
 }
 
 TEST(uri_test, full_uri_fragment_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_EQ("fragment", *instance.fragment());
+  ASSERT_EQ("fragment", instance.fragment());
 }
 
 TEST(uri_test, full_uri_range_scheme_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_TRUE(static_cast<bool>(instance.scheme()));
-  ASSERT_EQ("http", *instance.scheme());
+  ASSERT_TRUE(instance.has_scheme());
+  ASSERT_EQ("http", instance.scheme());
 }
 
 TEST(uri_test, full_uri_range_user_info_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_TRUE(static_cast<bool>(instance.user_info()));
-  ASSERT_EQ("user:password", *instance.user_info());
+  ASSERT_TRUE(instance.has_user_info());
+  ASSERT_EQ("user:password", instance.user_info());
 }
 
 TEST(uri_test, full_uri_range_host_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_TRUE(static_cast<bool>(instance.host()));
-  ASSERT_EQ("www.example.com", *instance.host());
+  ASSERT_TRUE(instance.has_host());
+  ASSERT_EQ("www.example.com", instance.host());
 }
 
 TEST(uri_test, full_uri_range_port_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_TRUE(static_cast<bool>(instance.port()));
-  ASSERT_EQ("80", *instance.port());
+  ASSERT_TRUE(instance.has_port());
+  ASSERT_EQ("80", instance.port());
 }
 
 TEST(uri_test, full_uri_range_path_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_TRUE(static_cast<bool>(instance.path()));
-  ASSERT_EQ("/path", *instance.path());
+  ASSERT_TRUE(instance.has_path());
+  ASSERT_EQ("/path", instance.path());
 }
 
 TEST(uri_test, full_uri_range_query_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_TRUE(static_cast<bool>(instance.query()));
-  ASSERT_EQ("query", *instance.query());
+  ASSERT_TRUE(instance.has_query());
+  ASSERT_EQ("query", instance.query());
 }
 
 TEST(uri_test, full_uri_range_fragment_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_TRUE(static_cast<bool>(instance.fragment()));
-  ASSERT_EQ("fragment", *instance.fragment());
+  ASSERT_TRUE(instance.has_fragment());
+  ASSERT_EQ("fragment", instance.fragment());
 }
 
 TEST(uri_test, mailto_test) {
   network::uri instance("mailto:john.doe@example.com");
-  ASSERT_EQ("mailto", *instance.scheme());
-  ASSERT_EQ("john.doe@example.com", *instance.path());
+  ASSERT_EQ("mailto", instance.scheme());
+  ASSERT_EQ("john.doe@example.com", instance.path());
 }
 
 TEST(uri_test, file_test) {
   network::uri instance("file:///bin/bash");
-  ASSERT_EQ("file", *instance.scheme());
-  ASSERT_EQ("/bin/bash", *instance.path());
+  ASSERT_EQ("file", instance.scheme());
+  ASSERT_EQ("/bin/bash", instance.path());
 }
 
 TEST(uri_test, xmpp_test) {
   network::uri instance("xmpp:example-node@example.com?message;subject=Hello%20World");
-  ASSERT_EQ("xmpp", *instance.scheme());
-  ASSERT_EQ("example-node@example.com", *instance.path());
-  ASSERT_EQ("message;subject=Hello%20World", *instance.query());
+  ASSERT_EQ("xmpp", instance.scheme());
+  ASSERT_EQ("example-node@example.com", instance.path());
+  ASSERT_EQ("message;subject=Hello%20World", instance.query());
 }
 
 TEST(uri_test, ipv4_address_test) {
   network::uri instance("http://129.79.245.252/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("129.79.245.252", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("129.79.245.252", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv4_loopback_test) {
   network::uri instance("http://127.0.0.1/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("127.0.0.1", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("127.0.0.1", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_address_test_1) {
   network::uri instance("http://[1080:0:0:0:8:800:200C:417A]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[1080:0:0:0:8:800:200C:417A]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[1080:0:0:0:8:800:200C:417A]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_address_test_2) {
   network::uri instance("http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[2001:db8:85a3:8d3:1319:8a2e:370:7348]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[2001:db8:85a3:8d3:1319:8a2e:370:7348]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_address_test_3) {
   network::uri instance("http://[2001:db8:85a3:0:0:8a2e:370:7334]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[2001:db8:85a3:0:0:8a2e:370:7334]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[2001:db8:85a3:0:0:8a2e:370:7334]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_address_test_4) {
   network::uri instance("http://[2001:db8:85a3::8a2e:370:7334]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[2001:db8:85a3::8a2e:370:7334]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[2001:db8:85a3::8a2e:370:7334]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_address_test_5) {
   network::uri instance("http://[2001:0db8:0000:0000:0000:0000:1428:57ab]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[2001:0db8:0000:0000:0000:0000:1428:57ab]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[2001:0db8:0000:0000:0000:0000:1428:57ab]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_address_test_6) {
   network::uri instance("http://[2001:0db8:0000:0000:0000::1428:57ab]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[2001:0db8:0000:0000:0000::1428:57ab]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[2001:0db8:0000:0000:0000::1428:57ab]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_address_test_7) {
   network::uri instance("http://[2001:0db8:0:0:0:0:1428:57ab]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[2001:0db8:0:0:0:0:1428:57ab]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[2001:0db8:0:0:0:0:1428:57ab]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_address_test_8) {
   network::uri instance("http://[2001:0db8:0:0::1428:57ab]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[2001:0db8:0:0::1428:57ab]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[2001:0db8:0:0::1428:57ab]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_address_test_9) {
   network::uri instance("http://[2001:0db8::1428:57ab]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[2001:0db8::1428:57ab]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[2001:0db8::1428:57ab]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_address_test_10) {
   network::uri instance("http://[2001:db8::1428:57ab]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[2001:db8::1428:57ab]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[2001:db8::1428:57ab]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_address_test_11) {
   network::uri instance("http://[::ffff:0c22:384e]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[::ffff:0c22:384e]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[::ffff:0c22:384e]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_address_test_12) {
   network::uri instance("http://[fe80::]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[fe80::]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[fe80::]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_address_test_13) {
   network::uri instance("http://[::ffff:c000:280]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[::ffff:c000:280]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[::ffff:c000:280]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_loopback_test) {
   network::uri instance("http://[::1]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[::1]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[::1]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_loopback_test_1) {
   network::uri instance("http://[0000:0000:0000:0000:0000:0000:0000:0001]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[0000:0000:0000:0000:0000:0000:0000:0001]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[0000:0000:0000:0000:0000:0000:0000:0001]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_v4inv6_test_1) {
   network::uri instance("http://[::ffff:12.34.56.78]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[::ffff:12.34.56.78]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[::ffff:12.34.56.78]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ipv6_v4inv6_test_2) {
   network::uri instance("http://[::ffff:192.0.2.128]/");
-  ASSERT_EQ("http", *instance.scheme());
-  ASSERT_EQ("[::ffff:192.0.2.128]", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("http", instance.scheme());
+  ASSERT_EQ("[::ffff:192.0.2.128]", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, ftp_test) {
   network::uri instance("ftp://john.doe@ftp.example.com/");
-  ASSERT_EQ("ftp", *instance.scheme());
-  ASSERT_EQ("john.doe", *instance.user_info());
-  ASSERT_EQ("ftp.example.com", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("ftp", instance.scheme());
+  ASSERT_EQ("john.doe", instance.user_info());
+  ASSERT_EQ("ftp.example.com", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, news_test) {
   network::uri instance("news:comp.infosystems.www.servers.unix");
-  ASSERT_EQ("news", *instance.scheme());
-  ASSERT_EQ("comp.infosystems.www.servers.unix", *instance.path());
+  ASSERT_EQ("news", instance.scheme());
+  ASSERT_EQ("comp.infosystems.www.servers.unix", instance.path());
 }
 
 TEST(uri_test, tel_test) {
   network::uri instance("tel:+1-816-555-1212");
-  ASSERT_EQ("tel", *instance.scheme());
-  ASSERT_EQ("+1-816-555-1212", *instance.path());
+  ASSERT_EQ("tel", instance.scheme());
+  ASSERT_EQ("+1-816-555-1212", instance.path());
 }
 
 TEST(uri_test, ldap_test) {
   network::uri instance("ldap://[2001:db8::7]/c=GB?objectClass?one");
-  ASSERT_EQ("ldap", *instance.scheme());
-  ASSERT_EQ("[2001:db8::7]", *instance.host());
-  ASSERT_EQ("/c=GB", *instance.path());
-  ASSERT_EQ("objectClass?one", *instance.query());
+  ASSERT_EQ("ldap", instance.scheme());
+  ASSERT_EQ("[2001:db8::7]", instance.host());
+  ASSERT_EQ("/c=GB", instance.path());
+  ASSERT_EQ("objectClass?one", instance.query());
 }
 
 TEST(uri_test, urn_test) {
   network::uri instance("urn:oasis:names:specification:docbook:dtd:xml:4.1.2");
-  ASSERT_EQ("urn", *instance.scheme());
-  ASSERT_EQ("oasis:names:specification:docbook:dtd:xml:4.1.2", *instance.path());
+  ASSERT_EQ("urn", instance.scheme());
+  ASSERT_EQ("oasis:names:specification:docbook:dtd:xml:4.1.2", instance.path());
 }
 
 TEST(uri_test, svn_ssh_test) {
   network::uri instance("svn+ssh://example.com/");
-  ASSERT_EQ("svn+ssh", *instance.scheme());
-  ASSERT_EQ("example.com", *instance.host());
-  ASSERT_EQ("/", *instance.path());
+  ASSERT_EQ("svn+ssh", instance.scheme());
+  ASSERT_EQ("example.com", instance.host());
+  ASSERT_EQ("/", instance.path());
 }
 
 TEST(uri_test, copy_constructor_test) {
@@ -428,14 +423,14 @@ TEST(uri_test, swap_test) {
 
 TEST(uri_test, authority_test) {
   network::uri instance("http://user:password@www.example.com:80/path?query#fragment");
-  ASSERT_TRUE(static_cast<bool>(instance.authority()));
-  ASSERT_EQ("user:password@www.example.com:80", *instance.authority());
+  ASSERT_TRUE(instance.has_authority());
+  ASSERT_EQ("user:password@www.example.com:80", instance.authority());
 }
 
 TEST(uri_test, partial_authority_test) {
   network::uri instance("http://www.example.com/path?query#fragment");
-  ASSERT_TRUE(static_cast<bool>(instance.authority()));
-  ASSERT_EQ("www.example.com", *instance.authority());
+  ASSERT_TRUE(instance.has_authority());
+  ASSERT_EQ("www.example.com", instance.authority());
 }
 
 TEST(uri_test, range_test) {
@@ -450,7 +445,7 @@ TEST(uri_test, issue_104_test) {
   std::unique_ptr<network::uri> instance(new network::uri("http://www.example.com/"));
   network::uri copy = *instance;
   instance.reset();
-  ASSERT_EQ("http", *copy.scheme());
+  ASSERT_EQ("http", copy.scheme());
 }
 
 TEST(uri_test, uri_set_test) {
@@ -474,37 +469,37 @@ TEST(uri_test, empty_uri) {
 
 TEST(uri_test, empty_uri_has_no_scheme) {
   network::uri instance;
-  ASSERT_FALSE(instance.scheme());
+  ASSERT_FALSE(instance.has_scheme());
 }
 
 TEST(uri_test, empty_uri_has_no_user_info) {
   network::uri instance;
-  ASSERT_FALSE(instance.user_info());
+  ASSERT_FALSE(instance.has_user_info());
 }
 
 TEST(uri_test, empty_uri_has_no_host) {
   network::uri instance;
-  ASSERT_FALSE(instance.host());
+  ASSERT_FALSE(instance.has_host());
 }
 
 TEST(uri_test, empty_uri_has_no_port) {
   network::uri instance;
-  ASSERT_FALSE(instance.port());
+  ASSERT_FALSE(instance.has_port());
 }
 
 TEST(uri_test, empty_uri_has_no_path) {
   network::uri instance;
-  ASSERT_FALSE(instance.path());
+  ASSERT_FALSE(instance.has_path());
 }
 
 TEST(uri_test, empty_uri_has_no_query) {
   network::uri instance;
-  ASSERT_FALSE(instance.query());
+  ASSERT_FALSE(instance.has_query());
 }
 
 TEST(uri_test, empty_uri_has_no_fragment) {
   network::uri instance;
-  ASSERT_FALSE(instance.fragment());
+  ASSERT_FALSE(instance.has_fragment());
 }
 
 TEST(uri_test, http_is_absolute) {
@@ -514,22 +509,22 @@ TEST(uri_test, http_is_absolute) {
 
 TEST(uri_test, mailto_has_no_user_info) {
   network::uri instance("mailto:john.doe@example.com");
-  ASSERT_FALSE(instance.user_info());
+  ASSERT_FALSE(instance.has_user_info());
 }
 
 TEST(uri_test, mailto_has_no_host) {
   network::uri instance("mailto:john.doe@example.com");
-  ASSERT_FALSE(instance.host());
+  ASSERT_FALSE(instance.has_host());
 }
 
 TEST(uri_test, mailto_has_no_port) {
   network::uri instance("mailto:john.doe@example.com");
-  ASSERT_FALSE(instance.port());
+  ASSERT_FALSE(instance.has_port());
 }
 
 TEST(uri_test, mailto_has_no_authority) {
   network::uri instance("mailto:john.doe@example.com");
-  ASSERT_FALSE(instance.authority());
+  ASSERT_FALSE(instance.has_authority());
 }
 
 TEST(uri_test, http_is_hierarchical) {
@@ -567,19 +562,19 @@ TEST(uri_test, unnormalized_invalid_path_doesnt_throw) {
 
 TEST(uri_test, unnormalized_invalid_path_is_valid) {
   network::uri instance("http://www.example.com/..");
-  ASSERT_TRUE(static_cast<bool>(instance.path()));
+  ASSERT_TRUE(instance.has_path());
 }
 
 TEST(uri_test, unnormalized_invalid_path_value) {
   network::uri instance("http://www.example.com/..");
-  ASSERT_EQ("/..", *instance.path());
+  ASSERT_EQ("/..", instance.path());
 }
 
 TEST(uri_test, git) {
   network::uri instance("git://github.com/cpp-netlib/cpp-netlib.git");
-  ASSERT_EQ("git", *instance.scheme());
-  ASSERT_EQ("github.com", *instance.host());
-  ASSERT_EQ("/cpp-netlib/cpp-netlib.git", *instance.path());
+  ASSERT_EQ("git", instance.scheme());
+  ASSERT_EQ("github.com", instance.host());
+  ASSERT_EQ("/cpp-netlib/cpp-netlib.git", instance.path());
 }
 
 TEST(uri_test, invalid_port_test) {
@@ -592,115 +587,110 @@ TEST(uri_test, valid_empty_port_test) {
 
 TEST(uri_test, empty_port_test) {
   network::uri instance("http://123.34.23.56:/");
-  ASSERT_TRUE(static_cast<bool>(instance.port()));
-  ASSERT_EQ("", *instance.port());
-}
-
-TEST(uri_test, empty_port_as_int_test) {
-  network::uri instance("http://123.34.23.56:/");
-  ASSERT_TRUE(!instance.port<int>());
+  ASSERT_TRUE(instance.has_port());
+  ASSERT_EQ("", instance.port());
 }
 
 TEST(uri_test, full_copy_uri_scheme_test) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = origin;
-  ASSERT_EQ("http", *instance.scheme());
+  ASSERT_EQ("http", instance.scheme());
 }
 
 TEST(uri_test, full_copy_uri_user_info_test) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = origin;
-  ASSERT_EQ("user:password", *instance.user_info());
+  ASSERT_EQ("user:password", instance.user_info());
 }
 
 TEST(uri_test, full_copy_uri_host_test) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = origin;
-  ASSERT_EQ("www.example.com", *instance.host());
+  ASSERT_EQ("www.example.com", instance.host());
 }
 
 TEST(uri_test, full_copy_uri_port_test) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = origin;
-  ASSERT_EQ("80", *instance.port());
+  ASSERT_EQ("80", instance.port());
 }
 
 TEST(uri_test, full_copy_uri_path_test) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = origin;
-  ASSERT_EQ("/path", *instance.path());
+  ASSERT_EQ("/path", instance.path());
 }
 
 TEST(uri_test, full_copy_uri_query_test) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = origin;
-  ASSERT_EQ("query", *instance.query());
+  ASSERT_EQ("query", instance.query());
 }
 
 TEST(uri_test, full_copy_uri_fragment_test) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = origin;
-  ASSERT_EQ("fragment", *instance.fragment());
+  ASSERT_EQ("fragment", instance.fragment());
 }
 
 TEST(uri_test, full_move_uri_scheme_test) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = std::move(origin);
-  ASSERT_EQ("http", *instance.scheme());
+  ASSERT_EQ("http", instance.scheme());
 }
 
 TEST(uri_test, full_move_uri_user_info_test) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = std::move(origin);
-  ASSERT_EQ("user:password", *instance.user_info());
+  ASSERT_EQ("user:password", instance.user_info());
 }
 
 TEST(uri_test, full_move_uri_host_test) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = std::move(origin);
-  ASSERT_EQ("www.example.com", *instance.host());
+  ASSERT_EQ("www.example.com", instance.host());
 }
 
 TEST(uri_test, full_move_uri_port_test) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = std::move(origin);
-  ASSERT_EQ("80", *instance.port());
+  ASSERT_EQ("80", instance.port());
 }
 
 TEST(uri_test, full_move_uri_path_test) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = std::move(origin);
-  ASSERT_EQ("/path", *instance.path());
+  ASSERT_EQ("/path", instance.path());
 }
 
 TEST(uri_test, full_move_uri_query_test) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = std::move(origin);
-  ASSERT_EQ("query", *instance.query());
+  ASSERT_EQ("query", instance.query());
 }
 
 TEST(uri_test, full_move_uri_fragment_test) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = std::move(origin);
-  ASSERT_EQ("fragment", *instance.fragment());
+  ASSERT_EQ("fragment", instance.fragment());
 }
 
 TEST(uri_test, mailto_uri_path) {
   network::uri origin("mailto:john.doe@example.com?query#fragment");
   network::uri instance = origin;
-  ASSERT_EQ("john.doe@example.com", *instance.path());
+  ASSERT_EQ("john.doe@example.com", instance.path());
 }
 
 TEST(uri_test, mailto_uri_query) {
   network::uri origin("mailto:john.doe@example.com?query#fragment");
   network::uri instance = origin;
-  ASSERT_EQ("query", *instance.query());
+  ASSERT_EQ("query", instance.query());
 }
 
 TEST(uri_test, mailto_uri_fragment) {
   network::uri origin("mailto:john.doe@example.com?query#fragment");
   network::uri instance = origin;
-  ASSERT_EQ("fragment", *instance.fragment());
+  ASSERT_EQ("fragment", instance.fragment());
 }
 
 TEST(uri_test, opaque_uri_with_one_slash) {
@@ -710,22 +700,22 @@ TEST(uri_test, opaque_uri_with_one_slash) {
 
 TEST(uri_test, opaque_uri_with_one_slash_scheme) {
   network::uri instance("scheme:/path/");
-  ASSERT_EQ("scheme", *instance.scheme());
+  ASSERT_EQ("scheme", instance.scheme());
 }
 
 TEST(uri_test, opaque_uri_with_one_slash_path) {
   network::uri instance("scheme:/path/");
-  ASSERT_EQ("/path/", *instance.path());
+  ASSERT_EQ("/path/", instance.path());
 }
 
 TEST(uri_test, opaque_uri_with_one_slash_query) {
   network::uri instance("scheme:/path/?query#fragment");
-  ASSERT_EQ("query", *instance.query());
+  ASSERT_EQ("query", instance.query());
 }
 
 TEST(uri_test, opaque_uri_with_one_slash_fragment) {
   network::uri instance("scheme:/path/?query#fragment");
-  ASSERT_EQ("fragment", *instance.fragment());
+  ASSERT_EQ("fragment", instance.fragment());
 }
 
 TEST(uri_test, opaque_uri_with_one_slash_copy) {
@@ -737,62 +727,62 @@ TEST(uri_test, opaque_uri_with_one_slash_copy) {
 TEST(uri_test, opaque_uri_with_one_slash_copy_query) {
   network::uri origin("scheme:/path/?query#fragment");
   network::uri instance = origin;
-  ASSERT_EQ("query", *instance.query());
+  ASSERT_EQ("query", instance.query());
 }
 
 TEST(uri_test, opaque_uri_with_one_slash_copy_fragment) {
   network::uri origin("scheme:/path/?query#fragment");
   network::uri instance = origin;
-  ASSERT_EQ("fragment", *instance.fragment());
+  ASSERT_EQ("fragment", instance.fragment());
 }
 
 TEST(uri_test, move_empty_uri_check_scheme) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = std::move(origin);
-  ASSERT_FALSE(origin.scheme());
+  ASSERT_FALSE(origin.has_scheme());
 }
 
 TEST(uri_test, move_empty_uri_check_user_info) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = std::move(origin);
-  ASSERT_FALSE(origin.user_info());
+  ASSERT_FALSE(origin.has_user_info());
 }
 
 TEST(uri_test, move_empty_uri_check_host) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = std::move(origin);
-  ASSERT_FALSE(origin.host());
+  ASSERT_FALSE(origin.has_host());
 }
 
 TEST(uri_test, move_empty_uri_check_port) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = std::move(origin);
-  ASSERT_FALSE(origin.port());
+  ASSERT_FALSE(origin.has_port());
 }
 
 TEST(uri_test, move_empty_uri_check_path) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = std::move(origin);
-  ASSERT_FALSE(origin.path());
+  ASSERT_FALSE(origin.has_path());
 }
 
 TEST(uri_test, move_empty_uri_check_query) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = std::move(origin);
-  ASSERT_FALSE(origin.query());
+  ASSERT_FALSE(origin.has_query());
 }
 
 TEST(uri_test, move_empty_uri_check_fragment) {
   network::uri origin("http://user:password@www.example.com:80/path?query#fragment");
   network::uri instance = std::move(origin);
-  ASSERT_FALSE(origin.fragment());
+  ASSERT_FALSE(origin.has_fragment());
 }
 
 TEST(uri_test, empty_username_in_user_info) {
   network::uri instance("ftp://:@localhost");
-  ASSERT_TRUE(static_cast<bool>(instance.user_info()));
-  ASSERT_EQ(":", *instance.user_info());
-  ASSERT_EQ("localhost", *instance.host());
+  ASSERT_TRUE(instance.has_user_info());
+  ASSERT_EQ(":", instance.user_info());
+  ASSERT_EQ("localhost", instance.host());
 }
 
 TEST(uri_test, uri_begins_with_a_colon) {


### PR DESCRIPTION
This is what we talked about earlier (or last night, if you are reading about this when you wake up).

I removed the use of optional, and updated all the tests. For me, all tests are green. So the following is up for discussion:

1. Do we need "bool has_x() const" if string_view::data() can be tested against nullptr;
2. What do we do with "template <typename intT> intT port() const"?

For 1, I think (weakly) that the answer is "yes"
For 2, I think throw an exception on error

I'm already comfortable with the idea of no longer using optional in this context, my experience already is that is much easier for the user to use and understand.
