### PR TITLE
Added tests for const and non-const non array string literals with the uri_builder.

### DIFF
--- a/include/network/uri/detail/translate.hpp
+++ b/include/network/uri/detail/translate.hpp
@@ -23,6 +23,16 @@ struct translate_impl<char[N]> {
   std::string operator()(const char *source) const { return source; }
 };
 
+template <>
+struct translate_impl<char *> {
+  std::string operator()(const char *source) const { return source; }
+};
+
+template <>
+struct translate_impl<const char *> {
+  std::string operator()(const char *source) const { return source; }
+};
+
 template <int N>
 struct translate_impl<const char[N]> {
   std::string operator()(const char *source) const { return source; }
@@ -45,6 +55,22 @@ struct translate_impl<const wchar_t[N]> {
 
 template <int N>
 struct translate_impl<wchar_t[N]> {
+  std::string operator()(const wchar_t *source) const {
+    translate_impl<std::wstring> impl;
+    return impl(source);
+  }
+};
+
+template <>
+struct translate_impl<wchar_t *> {
+  std::string operator()(const wchar_t *source) const {
+    translate_impl<std::wstring> impl;
+    return impl(source);
+  }
+};
+
+template <>
+struct translate_impl<const wchar_t *> {
   std::string operator()(const wchar_t *source) const {
     translate_impl<std::wstring> impl;
     return impl(source);

--- a/test/uri_builder_test.cpp
+++ b/test/uri_builder_test.cpp
@@ -722,3 +722,29 @@ TEST(builder_test, path_should_be_prefixed_with_slash_2) {
     .scheme("ftp").host("127.0.0.1").path("noleadingslash/foo.txt");
   ASSERT_EQ("/noleadingslash/foo.txt", builder.uri().path());
 }
+
+TEST(builder, non_array_string_literals_should_work) {
+  const char* p = "http";
+  const char* q = "foo";
+  network::uri_builder builder;
+
+  builder
+    .scheme(p)
+    .host("example.com")
+    .path(q)
+    ;
+  ASSERT_EQ("http://example.com/foo", builder.uri());
+}
+
+TEST(builder, non_const_non_array_string_literals_should_work) {
+  const char* p = "http";
+  const char* q = "foo";
+  network::uri_builder builder;
+
+  builder
+    .scheme(const_cast<char *>(p))
+    .host("example.com")
+    .path(const_cast<char *>(q))
+    ;
+  ASSERT_EQ("http://example.com/foo", builder.uri());
+}


### PR DESCRIPTION
Fixed issue reported in #68 
