### PR TITLE
Fix issue #90. Avoid nested include.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,4 +95,4 @@ if (Uri_BUILD_DOCS)
   endif()
 endif()
 
-install(DIRECTORY include DESTINATION include)
+install(DIRECTORY include DESTINATION ".")


### PR DESCRIPTION
Fix the CMakeLists file so there is only one include folder in the install directory.