### PR TITLE
fix port parsing for odd # of digits

### DIFF
--- a/src/detail/uri_parse.cpp
+++ b/src/detail/uri_parse.cpp
@@ -316,6 +316,7 @@ bool parse(string_view::const_iterator &it, string_view::const_iterator last,
       else if (!isdigit(it, last)) {
         return false;
       }
+      continue;
     }
     else if (hp_state == hier_part_state::path) {
       if (*it == '?') {

--- a/test/uri_parse_test.cpp
+++ b/test/uri_parse_test.cpp
@@ -125,6 +125,13 @@ TEST(uri_parse_test, test_hierarchical_part_valid_host_valid_port_empty_path) {
   ASSERT_TRUE(uri.path().empty());
 }
 
+TEST(uri_parse_test, test_hierarchical_part_valid_user_odd_digits_port) {
+  test::uri uri("http://user@www.example.com:12345/foo");
+  EXPECT_TRUE(uri.parse_uri());
+  ASSERT_TRUE(uri.has_port());
+  EXPECT_EQ("12345", uri.port());
+}
+
 TEST(uri_parse_test, test_hierarchical_part_valid_host_port_path) {
   test::uri uri("http://www.example.com:80/path");
   EXPECT_TRUE(uri.parse_uri());


### PR DESCRIPTION
This is quite puzzling at first - when userinfo exists in the uri, and the port has an odd # of digits, the port fails to parse.