### PR TITLE
Fixed missing declaration warning.

### DIFF
--- a/src/detail/uri_resolve.cpp
+++ b/src/detail/uri_resolve.cpp
@@ -26,6 +26,7 @@ void remove_last_segment(std::string& path) {
 }
 
 // implementation of http://tools.ietf.org/html/rfc3986#section-5.2.4
+static
 std::string remove_dot_segments(std::string input) {
   std::string result;
 


### PR DESCRIPTION
GCC's `-Wmissing-declarations` complains here. Also, not exporting this internal symbol is an improvement.