### PR TITLE
Introduce NETWORK_URI_EXTERNAL_BOOST to use an external version of boost

### DIFF
--- a/src/detail/uri_normalize.cpp
+++ b/src/detail/uri_normalize.cpp
@@ -6,8 +6,15 @@
 #include <iterator>
 #include <vector>
 #include <algorithm>
+
+#ifdef NETWORK_URI_EXTERNAL_BOOST
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/join.hpp>
+#else   // NETWORK_URI_EXTERNAL_BOOST
 #include "../boost/algorithm/string/split.hpp"
 #include "../boost/algorithm/string/join.hpp"
+#endif  // NETWORK_URI_EXTERNAL_BOOST
+
 #include "uri_normalize.hpp"
 #include "uri_percent_encode.hpp"
 #include "algorithm.hpp"

--- a/src/detail/uri_resolve.cpp
+++ b/src/detail/uri_resolve.cpp
@@ -6,10 +6,18 @@
 
 #include "uri_resolve.hpp"
 #include <algorithm>
+
+#ifdef NETWORK_URI_EXTERNAL_BOOST
+#include <boost/algorithm/string/find.hpp>
+#include <boost/algorithm/string/erase.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#else   // NETWORK_URI_EXTERNAL_BOOST
 #include "../boost/algorithm/string/find.hpp"
 #include "../boost/algorithm/string/erase.hpp"
 #include "../boost/algorithm/string/replace.hpp"
 #include "../boost/algorithm/string/predicate.hpp"
+#endif  // NETWORK_URI_EXTERNAL_BOOST
 
 namespace network {
 namespace detail {


### PR DESCRIPTION
I wanted to use an existing distribution of boost rather than the embedded one.
This required changing the includes.

Thus `NETWORK_URI_EXTERNAL_BOOST` is introduced to work use the boost distribution provided
by the include paths.