### PR TITLE
Use cascading ternary operators for C++11 mode

### DIFF
--- a/include/network/string_view.hpp
+++ b/include/network/string_view.hpp
@@ -161,9 +161,8 @@ class basic_string_view {
   }
 
   constexpr int compare(basic_string_view s) const noexcept {
-    if (size() != s.size())
-        return size() < s.size() ? -1 : 1;
-    return traits::compare(data(), s.data(), size());
+    return (size() != s.size()) ? (size() < s.size()) ? -1 : 1
+                                : traits::compare(data(), s.data(), size());
   }
 
   constexpr int compare(size_type pos1, size_type n1,


### PR DESCRIPTION
The comparison function is using C++14 constexpr, which is fine when we decide to move to C++14. In the meantime, let's support C++11 users.