### PR TITLE
Accept non-ASCII octets in percent-decoding

### DIFF
--- a/include/network/uri/detail/decode.hpp
+++ b/include/network/uri/detail/decode.hpp
@@ -40,10 +40,6 @@ InputIterator decode_char(InputIterator it, charT *out) {
   ++it;
   auto h1 = *it;
   auto v1 = detail::letter_to_hex(h1);
-  if (h0 >= '8') {
-    // unable to decode characters outside the ASCII character set.
-    throw percent_decoding_error(uri_error::conversion_failed);
-  }
   ++it;
   *out = static_cast<charT>((0x10 * v0) + v1);
   return it;

--- a/test/uri_encoding_test.cpp
+++ b/test/uri_encoding_test.cpp
@@ -134,3 +134,13 @@ TEST(uri_encoding_test, decode_iterator_not_an_error_2) {
   ASSERT_NO_THROW(network::uri::decode(std::begin(encoded), std::end(encoded),
 				       std::back_inserter(instance)));
 }
+
+TEST(uri_encoding_test, decode_accepts_utf8) {
+  const std::string encoded("%EB%B2%95%EC%A0%95%EB%8F%99");
+  std::string instance;
+  ASSERT_NO_THROW(network::uri::decode(std::begin(encoded), std::end(encoded),
+               std::back_inserter(instance)));
+
+  const std::string unencoded = u8"법정동";
+  ASSERT_EQ(unencoded, instance);
+}

--- a/test/uri_encoding_test.cpp
+++ b/test/uri_encoding_test.cpp
@@ -121,17 +121,16 @@ TEST(uri_encoding_test, decode_iterator_error_6) {
 	       network::percent_decoding_error);
 }
 
-TEST(uri_encoding_test, decode_iterator_not_an_error) {
+TEST(uri_encoding_test, decode_iterator_not_an_error_1) {
   const std::string encoded("%20");
   std::string instance;
   ASSERT_NO_THROW(network::uri::decode(std::begin(encoded), std::end(encoded),
 				       std::back_inserter(instance)));
 }
 
-TEST(uri_encoding_test, decode_iterator_error_7) {
+TEST(uri_encoding_test, decode_iterator_not_an_error_2) {
   const std::string encoded("%80");
   std::string instance;
-  ASSERT_THROW(network::uri::decode(std::begin(encoded), std::end(encoded),
-				    std::back_inserter(instance)),
-	       network::percent_decoding_error);
+  ASSERT_NO_THROW(network::uri::decode(std::begin(encoded), std::end(encoded),
+				       std::back_inserter(instance)));
 }


### PR DESCRIPTION
This PR fixes #118. All unit tests passed.

- Removed code that throws when an octet outside ASCII is detected.
- Changed a unit test that asserts decoding `%80` does **not** throw.
- Added a unit test that asserts decoding some UTF-8 does not throw.