### PR TITLE
Fix percent encoding in query component

### DIFF
--- a/include/network/uri/detail/encode.hpp
+++ b/include/network/uri/detail/encode.hpp
@@ -80,6 +80,15 @@ void encode_char(charT in, OutputIterator &out, const char *ignore = "") {
   }
 }
 
+template <class charT, class OutputIterator>
+void encode_pchar(charT in, OutputIterator &out) {
+  if (is_unreserved(in) || is_sub_delim(in) || (in == ':') || (in == '@')) {
+    out++ = in;
+  } else {
+    percent_encode(in, out);
+  }
+}
+
 template <typename InputIterator, typename OutputIterator>
 OutputIterator encode_user_info(InputIterator first, InputIterator last,
                                 OutputIterator out) {

--- a/include/network/uri/detail/encode.hpp
+++ b/include/network/uri/detail/encode.hpp
@@ -29,6 +29,13 @@ inline CharT hex_to_letter(CharT in) {
   return in;
 }
 
+template <class charT, class OutputIterator>
+void percent_encode(charT in, OutputIterator &out) {
+  out++ = '%';
+  out++ = hex_to_letter((in >> 4) & 0x0f);
+  out++ = hex_to_letter(in & 0x0f);
+}
+
 template <class charT>
 bool is_unreserved(charT in) {
   return ((in >= 'a') && (in <= 'z')) ||
@@ -60,33 +67,11 @@ bool is_sub_delim(charT in) {
 }
 
 template <class charT, class OutputIterator>
-void percent_encode(charT in, OutputIterator &out) {
-  out++ = '%';
-  out++ = hex_to_letter((in >> 4) & 0x0f);
-  out++ = hex_to_letter(in & 0x0f);
-}
-
-template <class charT, class OutputIterator>
 void encode_char(charT in, OutputIterator &out, const char *ignore = "") {
   if (is_unreserved(in)) {
     out++ = in;
   } else {
     auto first = ignore, last = ignore + std::strlen(ignore);
-    if (std::find(first, last, in) != last) {
-      out++ = in;
-    } else {
-      percent_encode(in, out);
-    }
-  }
-}
-
-template <class charT, class OutputIterator>
-void encode_pchar(charT in, OutputIterator &out, const char *ignore = "") {
-  if (is_unreserved(in) || is_sub_delim(in) || (in == ':') || (in == '@')) {
-    out++ = in;
-  } else {
-    auto first = ignore;
-    auto last = ignore + std::strlen(ignore);
     if (std::find(first, last, in) != last) {
       out++ = in;
     } else {
@@ -144,7 +129,7 @@ OutputIterator encode_query(InputIterator first, InputIterator last,
                             OutputIterator out) {
   auto it = first;
   while (it != last) {
-    detail::encode_pchar(*it, out, "/?");
+    detail::encode_char(*it, out, "/.@%;=");
     ++it;
   }
   return out;

--- a/include/network/uri/detail/encode.hpp
+++ b/include/network/uri/detail/encode.hpp
@@ -136,6 +136,17 @@ OutputIterator encode_query(InputIterator first, InputIterator last,
 }
 
 template <typename InputIterator, typename OutputIterator>
+OutputIterator encode_query_component(InputIterator first, InputIterator last,
+                                      OutputIterator out) {
+  auto it = first;
+  while (it != last) {
+    detail::encode_char(*it, out);
+    ++it;
+  }
+  return out;
+}
+
+template <typename InputIterator, typename OutputIterator>
 OutputIterator encode_fragment(InputIterator first, InputIterator last,
                                OutputIterator out) {
   auto it = first;

--- a/include/network/uri/detail/encode.hpp
+++ b/include/network/uri/detail/encode.hpp
@@ -121,7 +121,7 @@ OutputIterator encode_query_component(InputIterator first, InputIterator last,
                                       OutputIterator out) {
   auto it = first;
   while (it != last) {
-    detail::encode_char(*it, out);
+    detail::encode_char(*it, out, "/?");
     ++it;
   }
   return out;

--- a/include/network/uri/detail/encode.hpp
+++ b/include/network/uri/detail/encode.hpp
@@ -47,25 +47,6 @@ bool is_unreserved(charT in) {
          (in == '~');
 }
 
-template <class charT>
-bool is_sub_delim(charT in) {
-  switch (in) {
-    case '!':
-    case '$':
-    case '&':
-    case '\'':
-    case '(':
-    case ')':
-    case '*':
-    case '+':
-    case ',':
-    case ';':
-    case '=':
-      return true;
-  }
-  return false;
-}
-
 template <class charT, class OutputIterator>
 void encode_char(charT in, OutputIterator &out, const char *ignore = "") {
   if (is_unreserved(in)) {

--- a/include/network/uri/detail/encode.hpp
+++ b/include/network/uri/detail/encode.hpp
@@ -81,11 +81,17 @@ void encode_char(charT in, OutputIterator &out, const char *ignore = "") {
 }
 
 template <class charT, class OutputIterator>
-void encode_pchar(charT in, OutputIterator &out) {
+void encode_pchar(charT in, OutputIterator &out, const char *ignore = "") {
   if (is_unreserved(in) || is_sub_delim(in) || (in == ':') || (in == '@')) {
     out++ = in;
   } else {
-    percent_encode(in, out);
+    auto first = ignore;
+    auto last = ignore + std::strlen(ignore);
+    if (std::find(first, last, in) != last) {
+      out++ = in;
+    } else {
+      percent_encode(in, out);
+    }
   }
 }
 

--- a/include/network/uri/detail/encode.hpp
+++ b/include/network/uri/detail/encode.hpp
@@ -110,7 +110,7 @@ OutputIterator encode_query(InputIterator first, InputIterator last,
                             OutputIterator out) {
   auto it = first;
   while (it != last) {
-    detail::encode_char(*it, out, "/.@%;=");
+    detail::encode_char(*it, out, "/.@&%;=");
     ++it;
   }
   return out;

--- a/include/network/uri/detail/encode.hpp
+++ b/include/network/uri/detail/encode.hpp
@@ -60,6 +60,13 @@ bool is_sub_delim(charT in) {
 }
 
 template <class charT, class OutputIterator>
+void percent_encode(charT in, OutputIterator &out) {
+  out++ = '%';
+  out++ = hex_to_letter((in >> 4) & 0x0f);
+  out++ = hex_to_letter(in & 0x0f);
+}
+
+template <class charT, class OutputIterator>
 void encode_char(charT in, OutputIterator &out, const char *ignore = "") {
   if (is_unreserved(in)) {
     out++ = in;
@@ -68,9 +75,7 @@ void encode_char(charT in, OutputIterator &out, const char *ignore = "") {
     if (std::find(first, last, in) != last) {
       out++ = in;
     } else {
-      out++ = '%';
-      out++ = hex_to_letter((in >> 4) & 0x0f);
-      out++ = hex_to_letter(in & 0x0f);
+      percent_encode(in, out);
     }
   }
 }

--- a/include/network/uri/detail/encode.hpp
+++ b/include/network/uri/detail/encode.hpp
@@ -53,7 +53,7 @@ bool is_sub_delim(charT in) {
     case '+':
     case ',':
     case ';':
-    case '=';
+    case '=':
       return true;
   }
   return false;

--- a/include/network/uri/detail/encode.hpp
+++ b/include/network/uri/detail/encode.hpp
@@ -61,13 +61,7 @@ bool is_sub_delim(charT in) {
 
 template <class charT, class OutputIterator>
 void encode_char(charT in, OutputIterator &out, const char *ignore = "") {
-  if (((in >= 'a') && (in <= 'z')) ||
-      ((in >= 'A') && (in <= 'Z')) ||
-      ((in >= '0') && (in <= '9')) ||
-      (in == '-') ||
-      (in == '.') ||
-      (in == '_') ||
-      (in == '~')) {
+  if (is_unreserved(in)) {
     out++ = in;
   } else {
     auto first = ignore, last = ignore + std::strlen(ignore);

--- a/include/network/uri/detail/encode.hpp
+++ b/include/network/uri/detail/encode.hpp
@@ -29,6 +29,36 @@ inline CharT hex_to_letter(CharT in) {
   return in;
 }
 
+template <class charT>
+bool is_unreserved(charT in) {
+  return ((in >= 'a') && (in <= 'z')) ||
+         ((in >= 'A') && (in <= 'Z')) ||
+         ((in >= '0') && (in <= '9')) ||
+         (in == '-') ||
+         (in == '.') ||
+         (in == '_') ||
+         (in == '~');
+}
+
+template <class charT>
+bool is_sub_delim(charT in) {
+  switch (in) {
+    case '!':
+    case '$':
+    case '&':
+    case '\'':
+    case '(':
+    case ')':
+    case '*':
+    case '+':
+    case ',':
+    case ';':
+    case '=';
+      return true;
+  }
+  return false;
+}
+
 template <class charT, class OutputIterator>
 void encode_char(charT in, OutputIterator &out, const char *ignore = "") {
   if (((in >= 'a') && (in <= 'z')) ||

--- a/include/network/uri/detail/encode.hpp
+++ b/include/network/uri/detail/encode.hpp
@@ -144,7 +144,7 @@ OutputIterator encode_query(InputIterator first, InputIterator last,
                             OutputIterator out) {
   auto it = first;
   while (it != last) {
-    detail::encode_char(*it, out, "/.@&%;=");
+    detail::encode_pchar(*it, out, "/?");
     ++it;
   }
   return out;

--- a/include/network/uri/uri_builder.hpp
+++ b/include/network/uri/uri_builder.hpp
@@ -199,22 +199,15 @@ class uri_builder {
   uri_builder &clear_query();
 
   /**
-   * \brief Adds a new query to the uri_builder.
+   * \brief Adds a new query key/value pair to the uri_builder.
    * \param key The query key.
    * \param value The query value.
    * \returns \c *this
    */
   template <typename Key, typename Value>
-    uri_builder &append_query_key_value_pair(const Key &key, const Value &value) {
-    if (!query_) {
-      query_ = string_type();
-    }
-    else {
-      query_->append("&");
-    }
-    string_type query_pair = detail::translate(key) + "=" + detail::translate(value);
-    network::uri::encode_query(std::begin(query_pair), std::end(query_pair),
-                               std::back_inserter(*query_));
+  uri_builder &append_query_key_value_pair(const Key &key, const Value &value) {
+    append_query_key_value_pair(detail::translate(key),
+                                detail::translate(value));
     return *this;
   }
 
@@ -253,6 +246,7 @@ class uri_builder {
   void set_authority(string_type authority);
   void set_path(string_type path);
   void append_query(string_type query);
+  void append_query_key_value_pair(string_type key, string_type value);
   void set_fragment(string_type fragment);
 
   optional<string_type> scheme_, user_info_, host_, port_, path_, query_,

--- a/src/uri_builder.cpp
+++ b/src/uri_builder.cpp
@@ -122,6 +122,19 @@ void uri_builder::append_query(string_type query) {
                              std::back_inserter(*query_));
 }
 
+void uri_builder::append_query_key_value_pair(string_type key, string_type value) {
+  if (!query_) {
+    query_ = string_type();
+  } else {
+    query_->push_back('&');
+  }
+  detail::encode_query_component(std::begin(key), std::end(key),
+                                 std::back_inserter(*query_));
+  query_->push_back('=');
+  detail::encode_query_component(std::begin(value), std::end(value),
+                                 std::back_inserter(*query_));
+}
+
 uri_builder &uri_builder::clear_query() {
   query_ = network::nullopt;
   return *this;

--- a/test/uri_builder_test.cpp
+++ b/test/uri_builder_test.cpp
@@ -600,7 +600,7 @@ TEST(builder_test, build_uri_with_query_item_with_encoded_chars)
     .append_query_key_value_pair("a", "parameter with encoded chars!")
     .path("/")
     ;
-    ASSERT_EQ("http://www.example.com/?a=parameter%20with%20encoded%20chars%21", builder.uri().string());
+    ASSERT_EQ("http://www.example.com/?a=parameter%20with%20encoded%20chars!", builder.uri().string());
 }
 
 TEST(builder_test, build_uri_with_multiple_query_items_with_encoded_chars) {
@@ -612,7 +612,7 @@ TEST(builder_test, build_uri_with_multiple_query_items_with_encoded_chars) {
     .append_query_key_value_pair("b", "second parameter with encoded chars!")
     .path("/")
     ;
-    ASSERT_EQ("http://www.example.com/?a=first%20parameter%20with%20encoded%20chars%21&b=second%20parameter%20with%20encoded%20chars%21", builder.uri().string());
+    ASSERT_EQ("http://www.example.com/?a=first%20parameter%20with%20encoded%20chars!&b=second%20parameter%20with%20encoded%20chars!", builder.uri().string());
 }
 
 TEST(builder_test, construct_from_existing_uri) {

--- a/test/uri_builder_test.cpp
+++ b/test/uri_builder_test.cpp
@@ -600,7 +600,7 @@ TEST(builder_test, build_uri_with_query_item_with_encoded_chars)
     .append_query_key_value_pair("a", "parameter with encoded chars!")
     .path("/")
     ;
-    ASSERT_EQ("http://www.example.com/?a=parameter%20with%20encoded%20chars!", builder.uri().string());
+    ASSERT_EQ("http://www.example.com/?a=parameter%20with%20encoded%20chars%21", builder.uri().string());
 }
 
 TEST(builder_test, build_uri_with_multiple_query_items_with_encoded_chars) {
@@ -612,7 +612,7 @@ TEST(builder_test, build_uri_with_multiple_query_items_with_encoded_chars) {
     .append_query_key_value_pair("b", "second parameter with encoded chars!")
     .path("/")
     ;
-    ASSERT_EQ("http://www.example.com/?a=first%20parameter%20with%20encoded%20chars!&b=second%20parameter%20with%20encoded%20chars!", builder.uri().string());
+    ASSERT_EQ("http://www.example.com/?a=first%20parameter%20with%20encoded%20chars%21&b=second%20parameter%20with%20encoded%20chars%21", builder.uri().string());
 }
 
 TEST(builder_test, construct_from_existing_uri) {

--- a/test/uri_builder_test.cpp
+++ b/test/uri_builder_test.cpp
@@ -798,3 +798,33 @@ TEST(builder_test, construct_from_uri_bug_116) {
   const network::uri c(ub.uri());
   ASSERT_FALSE(c.has_port()) << c.string();
 }
+
+TEST(builder_test, append_query_key_value_pair_encodes_equals_sign) {
+  network::uri_builder ub(network::uri("http://example.com"));
+  ASSERT_NO_THROW(ub.append_query_key_value_pair("q", "="));
+  ASSERT_EQ(network::string_view("%3D"), ub.uri().query_begin()->second);
+}
+
+TEST(builder_test, append_query_key_value_pair_encodes_question_mark) {
+  network::uri_builder ub(network::uri("http://example.com"));
+  ASSERT_NO_THROW(ub.append_query_key_value_pair("q", "?"));
+  ASSERT_EQ(network::string_view("%3F"), ub.uri().query_begin()->second);
+}
+
+TEST(builder_test, append_query_key_value_pair_encodes_number_sign) {
+  network::uri_builder ub(network::uri("http://example.com"));
+  ASSERT_NO_THROW(ub.append_query_key_value_pair("q", "#"));
+  ASSERT_EQ(network::string_view("%23"), ub.uri().query_begin()->second);
+}
+
+TEST(builder_test, append_query_key_value_pair_encodes_percent_sign) {
+  network::uri_builder ub(network::uri("http://example.com"));
+  ASSERT_NO_THROW(ub.append_query_key_value_pair("q", "%"));
+  ASSERT_EQ(network::string_view("%25"), ub.uri().query_begin()->second);
+}
+
+TEST(builder_test, append_query_key_value_pair_encodes_ampersand) {
+  network::uri_builder ub(network::uri("http://example.com"));
+  ASSERT_NO_THROW(ub.append_query_key_value_pair("q", "&"));
+  ASSERT_EQ(network::string_view("%26"), ub.uri().query_begin()->second);
+}

--- a/test/uri_builder_test.cpp
+++ b/test/uri_builder_test.cpp
@@ -794,7 +794,7 @@ TEST(builder_test, construct_from_uri_bug_116) {
   const network::uri b("http://b.com");
   a = b;
 
-  network::uri_builder ub(a);  // ASAN reports heap-use-after-free here
+  network::uri_builder ub(a);
   const network::uri c(ub.uri());
   ASSERT_FALSE(c.has_port()) << c.string();
 }

--- a/test/uri_builder_test.cpp
+++ b/test/uri_builder_test.cpp
@@ -805,12 +805,6 @@ TEST(builder_test, append_query_key_value_pair_encodes_equals_sign) {
   ASSERT_EQ(network::string_view("%3D"), ub.uri().query_begin()->second);
 }
 
-TEST(builder_test, append_query_key_value_pair_encodes_question_mark) {
-  network::uri_builder ub(network::uri("http://example.com"));
-  ASSERT_NO_THROW(ub.append_query_key_value_pair("q", "?"));
-  ASSERT_EQ(network::string_view("%3F"), ub.uri().query_begin()->second);
-}
-
 TEST(builder_test, append_query_key_value_pair_encodes_number_sign) {
   network::uri_builder ub(network::uri("http://example.com"));
   ASSERT_NO_THROW(ub.append_query_key_value_pair("q", "#"));
@@ -827,4 +821,18 @@ TEST(builder_test, append_query_key_value_pair_encodes_ampersand) {
   network::uri_builder ub(network::uri("http://example.com"));
   ASSERT_NO_THROW(ub.append_query_key_value_pair("q", "&"));
   ASSERT_EQ(network::string_view("%26"), ub.uri().query_begin()->second);
+}
+
+TEST(builder_test, append_query_key_value_pair_does_not_encode_slash) {
+  // https://tools.ietf.org/html/rfc3986#section-3.4
+  network::uri_builder ub(network::uri("http://example.com"));
+  ASSERT_NO_THROW(ub.append_query_key_value_pair("q", "/"));
+  ASSERT_EQ(network::string_view("/"), ub.uri().query_begin()->second);
+}
+
+TEST(builder_test, append_query_key_value_pair_does_not_encode_qmark) {
+  // https://tools.ietf.org/html/rfc3986#section-3.4
+  network::uri_builder ub(network::uri("http://example.com"));
+  ASSERT_NO_THROW(ub.append_query_key_value_pair("q", "?"));
+  ASSERT_EQ(network::string_view("?"), ub.uri().query_begin()->second);
 }

--- a/test/uri_encoding_test.cpp
+++ b/test/uri_encoding_test.cpp
@@ -54,7 +54,7 @@ TEST(uri_encoding_test, encode_query_iterator) {
   std::string instance;
   network::uri::encode_query(std::begin(unencoded), std::end(unencoded),
 			     std::back_inserter(instance));
-  ASSERT_EQ("%21%23%24%26%27%28%29%2A%2B%2C/%3A;=%3F@%5B%5D", instance);
+  ASSERT_EQ("%21%23%24&%27%28%29%2A%2B%2C/%3A;=%3F@%5B%5D", instance);
 }
 
 TEST(uri_encoding_test, encode_fragment_iterator) {

--- a/test/uri_encoding_test.cpp
+++ b/test/uri_encoding_test.cpp
@@ -54,7 +54,7 @@ TEST(uri_encoding_test, encode_query_iterator) {
   std::string instance;
   network::uri::encode_query(std::begin(unencoded), std::end(unencoded),
 			     std::back_inserter(instance));
-  ASSERT_EQ("%21%23%24&%27%28%29%2A%2B%2C/%3A;=%3F@%5B%5D", instance);
+  ASSERT_EQ("!%23$&'()*+,/:;=?@%5B%5D", instance);
 }
 
 TEST(uri_encoding_test, encode_fragment_iterator) {

--- a/test/uri_encoding_test.cpp
+++ b/test/uri_encoding_test.cpp
@@ -54,7 +54,7 @@ TEST(uri_encoding_test, encode_query_iterator) {
   std::string instance;
   network::uri::encode_query(std::begin(unencoded), std::end(unencoded),
 			     std::back_inserter(instance));
-  ASSERT_EQ("!%23$&'()*+,/:;=?@%5B%5D", instance);
+  ASSERT_EQ("%21%23%24%26%27%28%29%2A%2B%2C/%3A;=%3F@%5B%5D", instance);
 }
 
 TEST(uri_encoding_test, encode_fragment_iterator) {

--- a/test/uri_encoding_test.cpp
+++ b/test/uri_encoding_test.cpp
@@ -10,7 +10,7 @@
 
 
 TEST(uri_encoding_test, encode_user_info_iterator) {
-  const std::string unencoded("!#$&\'()*+,/:;=?@[]");
+  const std::string unencoded("!#$&'()*+,/:;=?@[]");
   std::string instance;
   network::uri::encode_user_info(std::begin(unencoded), std::end(unencoded),
 				 std::back_inserter(instance));
@@ -18,7 +18,7 @@ TEST(uri_encoding_test, encode_user_info_iterator) {
 }
 
 TEST(uri_encoding_test, encode_host_iterator) {
-  const std::string unencoded("!#$&\'()*+,/:;=?@[]");
+  const std::string unencoded("!#$&'()*+,/:;=?@[]");
   std::string instance;
   network::uri::encode_host(std::begin(unencoded), std::end(unencoded),
 			    std::back_inserter(instance));
@@ -34,7 +34,7 @@ TEST(uri_encoding_test, encode_ipv6_host) {
 }
 
 TEST(uri_encoding_test, encode_port_iterator) {
-  const std::string unencoded("!#$&\'()*+,/:;=?@[]");
+  const std::string unencoded("!#$&'()*+,/:;=?@[]");
   std::string instance;
   network::uri::encode_port(std::begin(unencoded), std::end(unencoded),
 			    std::back_inserter(instance));
@@ -42,7 +42,7 @@ TEST(uri_encoding_test, encode_port_iterator) {
 }
 
 TEST(uri_encoding_test, encode_path_iterator) {
-  const std::string unencoded("!#$&\'()*+,/:;=?@[]");
+  const std::string unencoded("!#$&'()*+,/:;=?@[]");
   std::string instance;
   network::uri::encode_path(std::begin(unencoded), std::end(unencoded),
 			    std::back_inserter(instance));
@@ -50,7 +50,7 @@ TEST(uri_encoding_test, encode_path_iterator) {
 }
 
 TEST(uri_encoding_test, encode_query_iterator) {
-  const std::string unencoded("!#$&\'()*+,/:;=?@[]");
+  const std::string unencoded("!#$&'()*+,/:;=?@[]");
   std::string instance;
   network::uri::encode_query(std::begin(unencoded), std::end(unencoded),
 			     std::back_inserter(instance));
@@ -58,7 +58,7 @@ TEST(uri_encoding_test, encode_query_iterator) {
 }
 
 TEST(uri_encoding_test, encode_fragment_iterator) {
-  const std::string unencoded("!#$&\'()*+,/:;=?@[]");
+  const std::string unencoded("!#$&'()*+,/:;=?@[]");
   std::string instance;
   network::uri::encode_fragment(std::begin(unencoded), std::end(unencoded),
 				std::back_inserter(instance));
@@ -70,7 +70,7 @@ TEST(uri_encoding_test, decode_iterator) {
   std::string instance;
   network::uri::decode(std::begin(encoded), std::end(encoded),
 		       std::back_inserter(instance));
-  ASSERT_EQ("!#$&\'()*+,/:;=?@[]", instance);
+  ASSERT_EQ("!#$&'()*+,/:;=?@[]", instance);
 }
 
 TEST(uri_encoding_test, decode_iterator_error_1) {


### PR DESCRIPTION
This PR fixes percent-encoding when `uri_builder::append_query_key_value_pair()` is used.

There are two changes:
1. The key and value components are percent-encoded separately and then joined together with the `=` sign as separator.
2. The encode function `detail::encode_query_component()` that percent-encodes everything except unreserved characters, slash (`/`), and question mark (`?`) has been added for that purpose. This is in line with [RFC 3986 section 3.4](https://tools.ietf.org/html/rfc3986#section-3.4).

This way it is possible to use `=` and `%` in a key/value pair, because they'll be percent-encoded. Currently this is not possible since `=` and `%` are excluded from percent-encoding. The latter is even worse, because an URI decoder would expect a percent-encoded octet when reading the unencoded `%` sign.

- Some unit tests have also been added.
- All unit tests passed.

---
*Request for Comments*

The `uri_builder::append_query()` interface is easy to misuse in my opinion, which is sub-optimal for a class whose purpose is to create valid objects. Example:

```cpp
network::uri_builder ub(...);
ub.append_query("q=" + get_unchecked_input());
```

If `get_unchecked_input()` returns a string with characters in `/.@&%;=`, those characters will not be percent-encoded (see `detail::encode_query()`) which leads to broken URI strings. 

I would suggest to rename this function to `uri_builder::append_query_unsafe()` or removed it completely. What do you think?