### PR TITLE
Fix network_boost namespace compile error

### DIFF
--- a/src/detail/uri_normalize.cpp
+++ b/src/detail/uri_normalize.cpp
@@ -10,6 +10,7 @@
 #ifdef NETWORK_URI_EXTERNAL_BOOST
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/join.hpp>
+namespace network_boost = boost;
 #else   // NETWORK_URI_EXTERNAL_BOOST
 #include "../boost/algorithm/string/split.hpp"
 #include "../boost/algorithm/string/join.hpp"
@@ -50,7 +51,7 @@ std::string normalize_path_segments(string_view path) {
     for (const auto &segment : normalized_segments) {
       result += "/" + segment;
     }
-    
+
     if (last_segment_is_slash) {
       result += "/";
     }


### PR DESCRIPTION
This PR fixes a compile error in `uri_normalize.cpp` regarding an undefined `network_boost` namespace when using external Boost (`-DNETWORK_URI_EXTERNAL_BOOST`).

Reproduction:

```sh
g++ -std=c++11 -DNETWORK_URI_EXTERNAL_BOOST -Iinclude -c -o src/detail/uri_normalize.o src/detail/uri_normalize.cpp
deps/cppnetlib/deps/uri/src/detail/uri_normalize.cpp: In function ‘std::__cxx11::string network::detail::normalize_path_segments(network::string_view)’:
deps/cppnetlib/deps/uri/src/detail/uri_normalize.cpp:29:5: error: ‘network_boost’ has not been declared
     network_boost::split(path_segments, path, [](char ch) {
     ^
deps/cppnetlib/deps/uri/src/detail/uri_normalize.cpp:63:14: error: ‘network_boost’ has not been declared
     result = network_boost::join(normalized_segments, "/");
```

Boost version: 1.58
OS: Ubuntu 16.04.2