### PR TITLE
Fix namespace error with external boost

### DIFF
--- a/src/detail/uri_normalize.cpp
+++ b/src/detail/uri_normalize.cpp
@@ -10,6 +10,7 @@
 #ifdef NETWORK_URI_EXTERNAL_BOOST
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/join.hpp>
+namespace network_boost = boost;
 #else   // NETWORK_URI_EXTERNAL_BOOST
 #include "../boost/algorithm/string/split.hpp"
 #include "../boost/algorithm/string/join.hpp"
@@ -50,7 +51,7 @@ std::string normalize_path_segments(string_view path) {
     for (const auto &segment : normalized_segments) {
       result += "/" + segment;
     }
-    
+
     if (last_segment_is_slash) {
       result += "/";
     }

--- a/src/detail/uri_resolve.cpp
+++ b/src/detail/uri_resolve.cpp
@@ -12,6 +12,7 @@
 #include <boost/algorithm/string/erase.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+namespace network_boost = boost;
 #else   // NETWORK_URI_EXTERNAL_BOOST
 #include "../boost/algorithm/string/find.hpp"
 #include "../boost/algorithm/string/erase.hpp"


### PR DESCRIPTION
This PR fixes a compile error in `uri_resolve.cpp` regarding an undefined network_boost namespace when using external Boost (-DNETWORK_URI_EXTERNAL_BOOST).