### PR TITLE
Applied changes to percent encoding of query parameters in the uri_builder

### DIFF
--- a/include/network/uri/detail/encode.hpp
+++ b/include/network/uri/detail/encode.hpp
@@ -106,17 +106,6 @@ OutputIterator encode_path(InputIterator first, InputIterator last,
 }
 
 template <typename InputIterator, typename OutputIterator>
-OutputIterator encode_query(InputIterator first, InputIterator last,
-                            OutputIterator out) {
-  auto it = first;
-  while (it != last) {
-    detail::encode_char(*it, out, "/.@&%;");
-    ++it;
-  }
-  return out;
-}
-
-template <typename InputIterator, typename OutputIterator>
 OutputIterator encode_query_component(InputIterator first, InputIterator last,
                                       OutputIterator out) {
   auto it = first;
@@ -164,13 +153,6 @@ template <class String>
 String encode_path(const String &path) {
   String encoded;
   encode_path(std::begin(path), std::end(path), std::back_inserter(encoded));
-  return encoded;
-}
-
-template <class String>
-String encode_query(const String &query) {
-  String encoded;
-  encode_query(std::begin(query), std::end(query), std::back_inserter(encoded));
   return encoded;
 }
 

--- a/include/network/uri/detail/encode.hpp
+++ b/include/network/uri/detail/encode.hpp
@@ -110,7 +110,7 @@ OutputIterator encode_query(InputIterator first, InputIterator last,
                             OutputIterator out) {
   auto it = first;
   while (it != last) {
-    detail::encode_char(*it, out, "/.@&%;=");
+    detail::encode_char(*it, out, "/.@&%;");
     ++it;
   }
   return out;

--- a/include/network/uri/uri.hpp
+++ b/include/network/uri/uri.hpp
@@ -547,8 +547,8 @@ class uri {
   }
 
   /**
-   * \brief Encodes a sequence according to the rules for encoding a
-   *        query part.
+   * \deprecated Avoid using this function
+   * \brief Equivalent to \c encode_query_component
    * \param first The iterator at first element in the input
    *        sequence.
    * \param last The iterator at end + 1th element in the input
@@ -556,11 +556,51 @@ class uri {
    * \param out The iterator at the first element in the output
    *        sequence.
    * \returns The iterator at the end + 1th in the output sequence.
+   * \sa encode_query_commponent
+   * \sa encode_query_key_value_pair
    */
   template <typename InputIter, typename OutputIter>
   static OutputIter encode_query(InputIter first, InputIter last,
                                  OutputIter out) {
+    return encode_query_component(first, last, out);
+  }
+
+  /**
+   * \brief Encodes a sequence according to the rules for encoding a
+   *        query component, including the '=' character.
+   * \param first The iterator at first element in the input
+   *              sequence.
+   * \param last The iterator at end + 1th element in the input
+   *             sequence.
+   * \param out The iterator at the first element in the output
+   *            sequence.
+   * \returns The iterator at the end + 1th in the output sequence.
+   */
+  template <typename InputIter, typename OutputIter>
+  static OutputIter encode_query_component(
+      InputIter first, InputIter last, OutputIter out) {
     return detail::encode_query_component(first, last, out);
+  }
+
+  /**
+   * \brief Encodes a sequence according to the rules for encoding a
+   *        query key value pair.
+   * \param key_first The iterator at first element in the input
+   *                   sequence.
+   * \param key_last The iterator at end + 1th element in the input
+   *                  sequence.
+   * \param out The iterator at the first element in the output
+   *            sequence.
+   * \returns The iterator at the end + 1th in the output sequence.
+   */
+  template <typename InputIter, typename OutputIter>
+  static OutputIter encode_query_key_value_pair(
+      InputIter key_first, InputIter key_last,
+      InputIter value_first, InputIter value_last,
+      OutputIter out) {
+    out = detail::encode_query_component(key_first, key_last, out);
+    out++ = '=';
+    return detail::encode_query_component(value_first, value_last, out);
   }
 
   /**

--- a/include/network/uri/uri.hpp
+++ b/include/network/uri/uri.hpp
@@ -560,7 +560,7 @@ class uri {
   template <typename InputIter, typename OutputIter>
   static OutputIter encode_query(InputIter first, InputIter last,
                                  OutputIter out) {
-    return detail::encode_query(first, last, out);
+    return detail::encode_query_component(first, last, out);
   }
 
   /**

--- a/include/network/uri/uri_builder.hpp
+++ b/include/network/uri/uri_builder.hpp
@@ -182,13 +182,29 @@ class uri_builder {
   uri_builder &clear_path();
 
   /**
+   * \deprecated Please use append_query_parameter
+   * \warning This function's behaviour has changed and percent encoding
+   *          of the '=' character is not ignored.
    * \brief Adds a new query to the uri_builder.
    * \param query The query.
    * \returns \c *this
+   * \sa append_query_parameter
    */
   template <typename Source>
   uri_builder &append_query(const Source &query) {
-    append_query(detail::translate(query));
+    return append_query_parameter(query);
+  }
+
+  /**
+   * \brief Adds a new query value to the uri_builder. The '='
+   *        symbol is percent encoded.
+   * \param parameter The query parameter.
+   * \returns \c *this
+   * \sa append_query_key_value_pair
+   */
+  template <typename Source>
+  uri_builder &append_query_parameter(const Source &parameter) {
+    append_query_parameter(detail::translate(parameter));
     return *this;
   }
 
@@ -245,7 +261,7 @@ class uri_builder {
   void set_port(string_type port);
   void set_authority(string_type authority);
   void set_path(string_type path);
-  void append_query(string_type query);
+  void append_query_parameter(string_type query);
   void append_query_key_value_pair(string_type key, string_type value);
   void set_fragment(string_type fragment);
 

--- a/include/network/uri/uri_builder.hpp
+++ b/include/network/uri/uri_builder.hpp
@@ -198,13 +198,13 @@ class uri_builder {
   /**
    * \brief Adds a new query value to the uri_builder. The '='
    *        symbol is percent encoded.
-   * \param parameter The query parameter.
+   * \param name The query parameter.
    * \returns \c *this
    * \sa append_query_key_value_pair
    */
   template <typename Source>
-  uri_builder &append_query_parameter(const Source &parameter) {
-    append_query_parameter(detail::translate(parameter));
+  uri_builder &append_query_parameter(const Source &name) {
+    append_query_parameter(detail::translate(name));
     return *this;
   }
 
@@ -261,7 +261,7 @@ class uri_builder {
   void set_port(string_type port);
   void set_authority(string_type authority);
   void set_path(string_type path);
-  void append_query_parameter(string_type query);
+  void append_query_parameter(string_type name);
   void append_query_key_value_pair(string_type key, string_type value);
   void set_fragment(string_type fragment);
 

--- a/include/network/uri/uri_builder.hpp
+++ b/include/network/uri/uri_builder.hpp
@@ -182,7 +182,7 @@ class uri_builder {
   uri_builder &clear_path();
 
   /**
-   * \deprecated Please use append_query_parameter
+   * \deprecated Use append_query_component
    * \warning This function's behaviour has changed and percent encoding
    *          of the '=' character is not ignored.
    * \brief Adds a new query to the uri_builder.
@@ -192,32 +192,26 @@ class uri_builder {
    */
   template <typename Source>
   uri_builder &append_query(const Source &query) {
-    return append_query_parameter(query);
+    return append_query_component(query);
   }
 
   /**
-   * \brief Adds a new query value to the uri_builder. The '='
-   *        symbol is percent encoded.
-   * \param name The query parameter.
+   * \brief Appends a new query component to the uri_builder. The
+   *        '=' symbol is percent encoded.
+   * \param component The query component.
    * \returns \c *this
    * \sa append_query_key_value_pair
    */
   template <typename Source>
-  uri_builder &append_query_parameter(const Source &name) {
-    append_query_parameter(detail::translate(name));
+  uri_builder &append_query_component(const Source &component) {
+    append_query_component(detail::translate(component));
     return *this;
   }
 
   /**
-   * \brief Clears the URI query part.
-   * \returns \c *this
-   */
-  uri_builder &clear_query();
-
-  /**
    * \brief Adds a new query key/value pair to the uri_builder.
-   * \param key The query key.
-   * \param value The query value.
+   * \param key The query parameter key.
+   * \param value The query parameter value.
    * \returns \c *this
    */
   template <typename Key, typename Value>
@@ -226,6 +220,12 @@ class uri_builder {
                                 detail::translate(value));
     return *this;
   }
+
+  /**
+   * \brief Clears the URI query part.
+   * \returns \c *this
+   */
+  uri_builder &clear_query();
 
   /**
    * \brief Adds a new fragment to the uri_builder.
@@ -255,15 +255,15 @@ class uri_builder {
   network::uri uri() const;
 
  private:
-  void set_scheme(string_type scheme);
-  void set_user_info(string_type user_info);
-  void set_host(string_type host);
-  void set_port(string_type port);
-  void set_authority(string_type authority);
-  void set_path(string_type path);
-  void append_query_parameter(string_type name);
-  void append_query_key_value_pair(string_type key, string_type value);
-  void set_fragment(string_type fragment);
+  void set_scheme(string_type &&scheme);
+  void set_user_info(string_type &&user_info);
+  void set_host(string_type &&host);
+  void set_port(string_type &&port);
+  void set_authority(string_type &&authority);
+  void set_path(string_type &&path);
+  void append_query_component(string_type &&name);
+  void append_query_key_value_pair(string_type &&key, string_type &&value);
+  void set_fragment(string_type &&fragment);
 
   optional<string_type> scheme_, user_info_, host_, port_, path_, query_,
       fragment_;

--- a/src/uri.cpp
+++ b/src/uri.cpp
@@ -275,9 +275,7 @@ uri::query_iterator::query_iterator(optional<detail::uri_part> query)
 
 uri::query_iterator::query_iterator(const query_iterator &other)
   : query_(other.query_)
-  , kvp_(other.kvp_) {
-
-}
+  , kvp_(other.kvp_) {}
 
 uri::query_iterator &uri::query_iterator::operator = (const query_iterator &other) {
   auto tmp(other);

--- a/src/uri_builder.cpp
+++ b/src/uri_builder.cpp
@@ -44,14 +44,14 @@ uri_builder::~uri_builder() noexcept {}
 
 network::uri uri_builder::uri() const { return network::uri(*this); }
 
-void uri_builder::set_scheme(string_type scheme) {
+void uri_builder::set_scheme(string_type &&scheme) {
   // validate scheme is valid and normalize
   scheme_ = scheme;
   detail::transform(*scheme_, std::begin(*scheme_),
                     [] (char ch) { return std::tolower(ch, std::locale()); });
 }
 
-void uri_builder::set_user_info(string_type user_info) {
+void uri_builder::set_user_info(string_type &&user_info) {
   user_info_ = string_type();
   network::uri::encode_user_info(std::begin(user_info), std::end(user_info),
                                  std::back_inserter(*user_info_));
@@ -62,7 +62,7 @@ uri_builder &uri_builder::clear_user_info() {
   return *this;
 }
 
-void uri_builder::set_host(string_type host) {
+void uri_builder::set_host(string_type &&host) {
   host_ = string_type();
   network::uri::encode_host(std::begin(host), std::end(host),
                             std::back_inserter(*host_));
@@ -70,7 +70,7 @@ void uri_builder::set_host(string_type host) {
                     [](char ch) { return std::tolower(ch, std::locale()); });
 }
 
-void uri_builder::set_port(string_type port) {
+void uri_builder::set_port(string_type &&port) {
   port_ = string_type();
   network::uri::encode_port(std::begin(port), std::end(port),
                             std::back_inserter(*port_));
@@ -81,7 +81,7 @@ uri_builder &uri_builder::clear_port() {
   return *this;
 }
 
-void uri_builder::set_authority(string_type authority) {
+void uri_builder::set_authority(string_type &&authority) {
   optional<detail::uri_part> user_info, host, port;
   uri::string_view view(authority);
   uri::const_iterator it = std::begin(view), last = std::end(view);
@@ -100,7 +100,7 @@ void uri_builder::set_authority(string_type authority) {
   }
 }
 
-void uri_builder::set_path(string_type path) {
+void uri_builder::set_path(string_type &&path) {
   path_ = string_type();
   network::uri::encode_path(std::begin(path), std::end(path),
                             std::back_inserter(*path_));
@@ -111,28 +111,27 @@ uri_builder &uri_builder::clear_path() {
   return *this;
 }
 
-void uri_builder::append_query_parameter(string_type name) {
+void uri_builder::append_query_component(string_type &&name) {
   if (!query_) {
     query_ = string_type();
   }
   else {
     query_->append("&");
   }
-  network::uri::encode_query(std::begin(name), std::end(name),
-                             std::back_inserter(*query_));
+  network::uri::encode_query_component(
+      std::begin(name), std::end(name), std::back_inserter(*query_));
 }
 
-void uri_builder::append_query_key_value_pair(string_type key, string_type value) {
+void uri_builder::append_query_key_value_pair(string_type &&key, string_type &&value) {
   if (!query_) {
     query_ = string_type();
   } else {
     query_->push_back('&');
   }
-  detail::encode_query_component(std::begin(key), std::end(key),
-                                 std::back_inserter(*query_));
-  query_->push_back('=');
-  detail::encode_query_component(std::begin(value), std::end(value),
-                                 std::back_inserter(*query_));
+  network::uri::encode_query_key_value_pair(
+      std::begin(key), std::end(key),
+      std::begin(value), std::end(value),
+      std::back_inserter(*query_));
 }
 
 uri_builder &uri_builder::clear_query() {
@@ -140,7 +139,7 @@ uri_builder &uri_builder::clear_query() {
   return *this;
 }
 
-void uri_builder::set_fragment(string_type fragment) {
+void uri_builder::set_fragment(string_type &&fragment) {
   fragment_ = string_type();
   network::uri::encode_fragment(std::begin(fragment), std::end(fragment),
                                 std::back_inserter(*fragment_));

--- a/src/uri_builder.cpp
+++ b/src/uri_builder.cpp
@@ -32,7 +32,7 @@ uri_builder::uri_builder(const network::uri &base_uri) {
   }
 
   if (base_uri.has_query()) {
-    append_query(base_uri.query().to_string());
+    append_query_parameter(base_uri.query().to_string());
   }
 
   if (base_uri.has_fragment()) {
@@ -111,7 +111,7 @@ uri_builder &uri_builder::clear_path() {
   return *this;
 }
 
-void uri_builder::append_query(string_type query) {
+void uri_builder::append_query_parameter(string_type query) {
   if (!query_) {
     query_ = string_type();
   }

--- a/src/uri_builder.cpp
+++ b/src/uri_builder.cpp
@@ -12,31 +12,31 @@
 namespace network {
 uri_builder::uri_builder(const network::uri &base_uri) {
   if (base_uri.has_scheme()) {
-    set_scheme(base_uri.scheme().to_string());
+    scheme_ = base_uri.scheme().to_string();
   }
 
   if (base_uri.has_user_info()) {
-    set_user_info(base_uri.user_info().to_string());
+    user_info_ = base_uri.user_info().to_string();
   }
 
   if (base_uri.has_host()) {
-    set_host(base_uri.host().to_string());
+    host_ = base_uri.host().to_string();
   }
 
   if (base_uri.has_port()) {
-    set_port(base_uri.port().to_string());
+    port_ = base_uri.port().to_string();
   }
 
   if (base_uri.has_path()) {
-    set_path(base_uri.path().to_string());
+    path_ = base_uri.path().to_string();
   }
 
   if (base_uri.has_query()) {
-    append_query_parameter(base_uri.query().to_string());
+    query_ = base_uri.query().to_string();
   }
 
   if (base_uri.has_fragment()) {
-    set_fragment(base_uri.fragment().to_string());
+    fragment_ = base_uri.fragment().to_string();
   }
 }
 
@@ -111,14 +111,14 @@ uri_builder &uri_builder::clear_path() {
   return *this;
 }
 
-void uri_builder::append_query_parameter(string_type query) {
+void uri_builder::append_query_parameter(string_type name) {
   if (!query_) {
     query_ = string_type();
   }
   else {
     query_->append("&");
   }
-  network::uri::encode_query(std::begin(query), std::end(query),
+  network::uri::encode_query(std::begin(name), std::end(name),
                              std::back_inserter(*query_));
 }
 

--- a/test/uri_builder_test.cpp
+++ b/test/uri_builder_test.cpp
@@ -217,7 +217,7 @@ TEST(builder_test, full_uri_doesnt_throw) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
   ASSERT_NO_THROW(builder.uri());
@@ -231,10 +231,10 @@ TEST(builder_test, full_uri) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
-  ASSERT_EQ("http://user@www.example.com:80/path?query#fragment", builder.uri().string());
+  ASSERT_EQ("http://user@www.example.com:80/path?query=value#fragment", builder.uri().string());
 }
 
 TEST(builder_test, full_uri_has_scheme) {
@@ -245,7 +245,7 @@ TEST(builder_test, full_uri_has_scheme) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
   ASSERT_TRUE(builder.uri().has_scheme());
@@ -259,7 +259,7 @@ TEST(builder_test, full_uri_scheme_value) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
   ASSERT_EQ("http", builder.uri().scheme());
@@ -273,7 +273,7 @@ TEST(builder_test, full_uri_has_user_info) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
   ASSERT_TRUE(builder.uri().has_user_info());
@@ -287,7 +287,7 @@ TEST(builder_test, full_uri_user_info_value) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
   ASSERT_EQ("user", builder.uri().user_info());
@@ -301,7 +301,7 @@ TEST(builder_test, full_uri_has_host) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
   ASSERT_TRUE(builder.uri().has_host());
@@ -315,7 +315,7 @@ TEST(builder_test, full_uri_host_value) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
   ASSERT_EQ("www.example.com", builder.uri().host());
@@ -329,7 +329,7 @@ TEST(builder_test, full_uri_has_port) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
   ASSERT_TRUE(builder.uri().has_port());
@@ -343,7 +343,7 @@ TEST(builder_test, full_uri_has_path) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
   ASSERT_TRUE(builder.uri().has_path());
@@ -357,7 +357,7 @@ TEST(builder_test, full_uri_path_value) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
   ASSERT_EQ("/path", builder.uri().path());
@@ -371,7 +371,7 @@ TEST(builder_test, full_uri_has_query) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
   ASSERT_TRUE(builder.uri().has_query());
@@ -385,10 +385,10 @@ TEST(builder_test, full_uri_query_value) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
-  ASSERT_EQ("query", builder.uri().query());
+  ASSERT_EQ("query=value", builder.uri().query());
 }
 
 TEST(builder_test, full_uri_has_fragment) {
@@ -399,7 +399,7 @@ TEST(builder_test, full_uri_has_fragment) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
   ASSERT_TRUE(builder.uri().has_fragment());
@@ -413,7 +413,7 @@ TEST(builder_test, full_uri_fragment_value) {
     .host("www.example.com")
     .port("80")
     .path("/path")
-    .append_query("query")
+    .append_query_key_value_pair("query", "value")
     .fragment("fragment")
     ;
   ASSERT_EQ("fragment", builder.uri().fragment());
@@ -722,17 +722,6 @@ TEST(builder_test, set_multiple_query_with_encoding) {
   builder
     .scheme("http")
     .host("example.com")
-    .append_query("q1=foo bar")
-    .append_query("q2=biz baz")
-    ;
-  ASSERT_EQ("http://example.com?q1=foo%20bar&q2=biz%20baz", builder.uri().string());
-}
-
-TEST(builder_test, set_multiple_query_with_encoding_2) {
-  network::uri_builder builder;
-  builder
-    .scheme("http")
-    .host("example.com")
     .append_query_key_value_pair("q1", "foo bar")
     .append_query_key_value_pair("q2", "biz baz")
     ;
@@ -799,9 +788,22 @@ TEST(builder_test, construct_from_uri_bug_116) {
   ASSERT_FALSE(c.has_port()) << c.string();
 }
 
+TEST(builder_test, append_query_value) {
+  network::uri_builder ub(network::uri("http://example.com"));
+  ASSERT_NO_THROW(ub.append_query_parameter("q"));
+  ASSERT_EQ(network::string_view("q"), ub.uri().query_begin()->first);
+}
+
+TEST(builder_test, append_query_value_encodes_equal_sign) {
+  network::uri_builder ub(network::uri("http://example.com"));
+  ASSERT_NO_THROW(ub.append_query_parameter("="));
+  ASSERT_EQ(network::string_view("%3D"), ub.uri().query_begin()->first);
+}
+
 TEST(builder_test, append_query_key_value_pair_encodes_equals_sign) {
   network::uri_builder ub(network::uri("http://example.com"));
   ASSERT_NO_THROW(ub.append_query_key_value_pair("q", "="));
+  ASSERT_EQ(network::string_view("q"), ub.uri().query_begin()->first);
   ASSERT_EQ(network::string_view("%3D"), ub.uri().query_begin()->second);
 }
 

--- a/test/uri_builder_test.cpp
+++ b/test/uri_builder_test.cpp
@@ -790,13 +790,13 @@ TEST(builder_test, construct_from_uri_bug_116) {
 
 TEST(builder_test, append_query_value) {
   network::uri_builder ub(network::uri("http://example.com"));
-  ASSERT_NO_THROW(ub.append_query_parameter("q"));
+  ASSERT_NO_THROW(ub.append_query_component("q"));
   ASSERT_EQ(network::string_view("q"), ub.uri().query_begin()->first);
 }
 
 TEST(builder_test, append_query_value_encodes_equal_sign) {
   network::uri_builder ub(network::uri("http://example.com"));
-  ASSERT_NO_THROW(ub.append_query_parameter("="));
+  ASSERT_NO_THROW(ub.append_query_component("="));
   ASSERT_EQ(network::string_view("%3D"), ub.uri().query_begin()->first);
 }
 

--- a/test/uri_builder_test.cpp
+++ b/test/uri_builder_test.cpp
@@ -838,3 +838,18 @@ TEST(builder_test, append_query_key_value_pair_does_not_encode_qmark) {
   ASSERT_NO_THROW(ub.append_query_key_value_pair("q", "?"));
   ASSERT_EQ(network::string_view("?"), ub.uri().query_begin()->second);
 }
+
+TEST(builder_test, build_from_uri_with_encoded_user_info) {
+  network::uri_builder ub(network::uri("http://%40@example.com"));
+  ASSERT_EQ(network::string_view("%40"), ub.uri().user_info());
+}
+
+TEST(builder_test, build_from_uri_with_encoded_query) {
+  network::uri_builder ub(network::uri("http://example.com?x=%40"));
+  ASSERT_EQ(network::string_view("x=%40"), ub.uri().query());
+}
+
+TEST(builder_test, build_from_uri_with_encoded_fragment) {
+  network::uri_builder ub(network::uri("http://example.com#%40"));
+  ASSERT_EQ(network::string_view("%40"), ub.uri().fragment());
+}

--- a/test/uri_encoding_test.cpp
+++ b/test/uri_encoding_test.cpp
@@ -49,19 +49,19 @@ TEST(uri_encoding_test, encode_path_iterator) {
   ASSERT_EQ("%21%23%24%26%27%28%29%2A%2B%2C/%3A;=%3F@%5B%5D", instance);
 }
 
-TEST(uri_encoding_test, encode_query_iterator) {
+TEST(uri_encoding_test, encode_query_component_iterator) {
   const std::string unencoded("!#$&'()*+,/:;=?@[]");
   std::string instance;
-  network::uri::encode_query(std::begin(unencoded), std::end(unencoded),
-			     std::back_inserter(instance));
+  network::uri::encode_query_component(
+      std::begin(unencoded), std::end(unencoded), std::back_inserter(instance));
   ASSERT_EQ("%21%23%24%26%27%28%29%2A%2B%2C/%3A%3B%3D?%40%5B%5D", instance);
 }
 
 TEST(uri_encoding_test, encode_fragment_iterator) {
   const std::string unencoded("!#$&'()*+,/:;=?@[]");
   std::string instance;
-  network::uri::encode_fragment(std::begin(unencoded), std::end(unencoded),
-				std::back_inserter(instance));
+  network::uri::encode_fragment(
+      std::begin(unencoded), std::end(unencoded), std::back_inserter(instance));
   ASSERT_EQ("%21%23%24&%27%28%29%2A%2B%2C/%3A;=%3F@%5B%5D", instance);
 }
 

--- a/test/uri_encoding_test.cpp
+++ b/test/uri_encoding_test.cpp
@@ -54,7 +54,7 @@ TEST(uri_encoding_test, encode_query_iterator) {
   std::string instance;
   network::uri::encode_query(std::begin(unencoded), std::end(unencoded),
 			     std::back_inserter(instance));
-  ASSERT_EQ("%21%23%24&%27%28%29%2A%2B%2C/%3A;%3D%3F@%5B%5D", instance);
+  ASSERT_EQ("%21%23%24%26%27%28%29%2A%2B%2C/%3A%3B%3D?%40%5B%5D", instance);
 }
 
 TEST(uri_encoding_test, encode_fragment_iterator) {

--- a/test/uri_encoding_test.cpp
+++ b/test/uri_encoding_test.cpp
@@ -54,7 +54,7 @@ TEST(uri_encoding_test, encode_query_iterator) {
   std::string instance;
   network::uri::encode_query(std::begin(unencoded), std::end(unencoded),
 			     std::back_inserter(instance));
-  ASSERT_EQ("%21%23%24&%27%28%29%2A%2B%2C/%3A;=%3F@%5B%5D", instance);
+  ASSERT_EQ("%21%23%24&%27%28%29%2A%2B%2C/%3A;%3D%3F@%5B%5D", instance);
 }
 
 TEST(uri_encoding_test, encode_fragment_iterator) {

--- a/test/uri_resolve_test.cpp
+++ b/test/uri_resolve_test.cpp
@@ -245,12 +245,12 @@ TEST_F(uri_resolve_test, abnormal_example_14) {
 }
 
 TEST_F(uri_resolve_test, abnormal_example_15) {
-  uri reference = uri_builder().path("g").append_query_parameter("y/./x").uri();
+  uri reference = uri_builder().path("g").append_query_component("y/./x").uri();
   ASSERT_EQ("http://a/b/c/g?y/./x", resolved(reference));
 }
 
 TEST_F(uri_resolve_test, abnormal_example_16) {
-  uri reference = uri_builder().path("g").append_query_parameter("y/../x").uri();
+  uri reference = uri_builder().path("g").append_query_component("y/../x").uri();
   ASSERT_EQ("http://a/b/c/g?y/../x", resolved(reference));
 }
 

--- a/test/uri_resolve_test.cpp
+++ b/test/uri_resolve_test.cpp
@@ -41,8 +41,8 @@ TEST_F(uri_resolve_test, base_has_empty_path__path_is_ref_path_1)
 
 TEST_F(uri_resolve_test, base_has_empty_path__path_is_ref_path_2)
 {
-  uri reference = uri_builder().path("g/x/y").append_query("q").fragment("s").uri();
-  ASSERT_EQ("http://a/g/x/y?q#s", resolved(uri("http://a/"), reference));
+  uri reference = uri_builder().path("g/x/y").append_query_key_value_pair("q", "1").fragment("s").uri();
+  ASSERT_EQ("http://a/g/x/y?q=1#s", resolved(uri("http://a/"), reference));
 }
 
 // normal examples
@@ -69,8 +69,8 @@ TEST_F(uri_resolve_test, path_starts_with_slash__path_is_ref_path) {
 }
 
 TEST_F(uri_resolve_test, path_starts_with_slash_with_query_fragment__path_is_ref_path) {
-  uri reference = uri_builder().path("/g/x").append_query("y").fragment("s").uri();
-  ASSERT_EQ("http://a/g/x?y#s", resolved(reference));
+  uri reference = uri_builder().path("/g/x").append_query_key_value_pair("y", "z").fragment("s").uri();
+  ASSERT_EQ("http://a/g/x?y=z#s", resolved(reference));
 }
 
 TEST_F(uri_resolve_test, DISABLED_has_authority__base_scheme_with_ref_authority) {
@@ -81,18 +81,18 @@ TEST_F(uri_resolve_test, DISABLED_has_authority__base_scheme_with_ref_authority)
 }
 
 TEST_F(uri_resolve_test, path_is_empty_but_has_query__returns_base_with_ref_query) {
-  uri reference = uri_builder().append_query("y").uri();
-  ASSERT_EQ("http://a/b/c/d;p?y", resolved(reference));
+  uri reference = uri_builder().append_query_key_value_pair("y", "z").uri();
+  ASSERT_EQ("http://a/b/c/d;p?y=z", resolved(reference));
 }
 
 TEST_F(uri_resolve_test, path_is_empty_but_has_query_base_no_query__returns_base_with_ref_query) {
-  uri reference = uri_builder().append_query("y").uri();
-  ASSERT_EQ("http://a/b/c/d?y", resolved(uri("http://a/b/c/d"), reference));
+  uri reference = uri_builder().append_query_key_value_pair("y", "z").uri();
+  ASSERT_EQ("http://a/b/c/d?y=z", resolved(uri("http://a/b/c/d"), reference));
 }
 
 TEST_F(uri_resolve_test, merge_path_with_query) {
-  uri reference = uri_builder().path("g").append_query("y").uri();
-  ASSERT_EQ("http://a/b/c/g?y", resolved(reference));
+  uri reference = uri_builder().path("g").append_query_key_value_pair("y", "z").uri();
+  ASSERT_EQ("http://a/b/c/g?y=z", resolved(reference));
 }
 
 TEST_F(uri_resolve_test, append_fragment) {
@@ -106,8 +106,8 @@ TEST_F(uri_resolve_test, merge_paths_with_fragment) {
 }
 
 TEST_F(uri_resolve_test, merge_paths_with_query_and_fragment) {
-  uri reference = uri_builder().path("g").append_query("y").fragment("s").uri();
-  ASSERT_EQ("http://a/b/c/g?y#s", resolved(reference));
+  uri reference = uri_builder().path("g").append_query_key_value_pair("y", "z").fragment("s").uri();
+  ASSERT_EQ("http://a/b/c/g?y=z#s", resolved(reference));
 }
 
 TEST_F(uri_resolve_test, merge_paths_with_semicolon_1) {
@@ -121,8 +121,8 @@ TEST_F(uri_resolve_test, merge_paths_with_semicolon_2) {
 }
 
 TEST_F(uri_resolve_test, merge_paths_with_semicolon_3) {
-  uri reference = uri_builder().path("g;x").append_query("y").fragment("s").uri();
-  ASSERT_EQ("http://a/b/c/g;x?y#s", resolved(reference));
+  uri reference = uri_builder().path("g;x").append_query_key_value_pair("y", "z").fragment("s").uri();
+  ASSERT_EQ("http://a/b/c/g;x?y=z#s", resolved(reference));
 }
 
 TEST_F(uri_resolve_test, path_is_empty__returns_base) {
@@ -245,12 +245,12 @@ TEST_F(uri_resolve_test, abnormal_example_14) {
 }
 
 TEST_F(uri_resolve_test, abnormal_example_15) {
-  uri reference = uri_builder().path("g").append_query("y/./x").uri();
+  uri reference = uri_builder().path("g").append_query_parameter("y/./x").uri();
   ASSERT_EQ("http://a/b/c/g?y/./x", resolved(reference));
 }
 
 TEST_F(uri_resolve_test, abnormal_example_16) {
-  uri reference = uri_builder().path("g").append_query("y/../x").uri();
+  uri reference = uri_builder().path("g").append_query_parameter("y/../x").uri();
   ASSERT_EQ("http://a/b/c/g?y/../x", resolved(reference));
 }
 


### PR DESCRIPTION
Applies fix for #121 .

I've added `append_query_parameter` and deprecated `append_query`. The behaviour of `append_query` has changed and is strongly recommended not to use it. The behaviour before was unsafe anyway, so that I hope that with the documented warning and deprecation, this should be OK.

I updated some tests to reflect the changes.

Please also consider the consistency of the implementation of query_iterator in your review.